### PR TITLE
[ScalarOps AI] Improve engagement and reduce bounce rate with clearer navigation to /skills and /docs

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,8 @@ import { authRoutes } from "./routes/auth.js";
 import { blobRoutes } from "./routes/blobs.js";
 import { accountRoutes } from "./routes/account.js";
 import { skillsRouter } from "./routes/skills.js";
+import { jsonldRouter } from "./routes/jsonld.js";
+import { pagesRouter } from "./routes/pages.js";
 
 const app = new Hono();
 
@@ -55,6 +57,8 @@ app.route("/auth", authRoutes);
 app.route("/blobs", blobRoutes);
 app.route("/account", accountRoutes);
 app.route("/skills", skillsRouter);
+app.route("/jsonld", jsonldRouter);
+app.route("/pages", pagesRouter);
 
 // 404 handler
 app.notFound((c) => {

--- a/packages/server/src/jsonld.ts
+++ b/packages/server/src/jsonld.ts
@@ -248,3 +248,56 @@ export const webPageSchema = (
     url: SITE_URL,
   },
 });
+
+/**
+ * BreadcrumbList schema for navigation
+ */
+export const breadcrumbSchema = (
+  items: { name: string; url: string }[]
+): JsonLdSchema => ({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: items.map((item, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    name: item.name,
+    item: item.url,
+  })),
+});
+
+/**
+ * SiteNavigationElement schema for key pages
+ */
+export const siteNavigationSchema = (): JsonLdSchema => ({
+  "@context": "https://schema.org",
+  "@type": "SiteNavigationElement",
+  name: "Main Navigation",
+  url: SITE_URL,
+  hasPart: [
+    {
+      "@type": "WebPage",
+      name: "Skills Catalog",
+      url: `${SITE_URL}/skills`,
+      description: "Browse and install reusable Claude Code skills",
+    },
+    {
+      "@type": "WebPage",
+      name: "Documentation",
+      url: `${SITE_URL}/docs`,
+      description: "Get started with Claude Skill Manager",
+    },
+    {
+      "@type": "WebPage",
+      name: "What are Claude Code Skills?",
+      url: `${SITE_URL}/what-are-claude-code-skills`,
+      description:
+        "Learn how skills extend Claude Code with reusable prompts",
+    },
+    {
+      "@type": "WebPage",
+      name: "Open Source",
+      url: `${SITE_URL}/open-source`,
+      description: "Open source libraries powering Skill Manager",
+    },
+  ],
+});

--- a/packages/server/src/pages.ts
+++ b/packages/server/src/pages.ts
@@ -1,0 +1,376 @@
+/**
+ * Page content data for engagement improvements
+ *
+ * Serves structured CTA, internal linking, and navigation data
+ * that the frontend uses to render engagement elements.
+ */
+
+const SITE_URL = "https://claudeskill.io";
+
+export type Cta = {
+  text: string;
+  href: string;
+  variant: "primary" | "secondary";
+};
+
+export type InternalLink = {
+  text: string;
+  href: string;
+  context: string;
+};
+
+export type Breadcrumb = {
+  label: string;
+  href: string;
+};
+
+export type PageEngagement = {
+  ctas: Cta[];
+  internalLinks: InternalLink[];
+  breadcrumbs: Breadcrumb[];
+  nextSteps: Cta[];
+};
+
+/**
+ * Homepage engagement data — above-the-fold CTAs directing to /skills and /docs
+ */
+export const homePageEngagement = (): PageEngagement => ({
+  ctas: [
+    {
+      text: "Browse Skills",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Read the Docs",
+      href: "/docs",
+      variant: "secondary",
+    },
+  ],
+  internalLinks: [
+    {
+      text: "What are Claude Code Skills?",
+      href: "/what-are-claude-code-skills",
+      context:
+        "New to skills? Learn how reusable prompts and workflows supercharge your Claude Code setup.",
+    },
+    {
+      text: "Browse the skill catalog",
+      href: "/skills",
+      context:
+        "Discover ready-to-install skills for linting, formatting, git workflows, and more.",
+    },
+    {
+      text: "Get started with the docs",
+      href: "/docs",
+      context:
+        "Step-by-step guide to installing your first skill and syncing across devices.",
+    },
+    {
+      text: "View open source dependencies",
+      href: "/open-source",
+      context:
+        "See the open source libraries that power Claude Skill Manager.",
+    },
+  ],
+  breadcrumbs: [{ label: "Home", href: "/" }],
+  nextSteps: [
+    {
+      text: "Install your first skill",
+      href: "/docs",
+      variant: "primary",
+    },
+    {
+      text: "Explore the catalog",
+      href: "/skills",
+      variant: "secondary",
+    },
+  ],
+});
+
+/**
+ * Skills page engagement data — CTA to docs for getting started
+ */
+export const skillsPageEngagement = (): PageEngagement => ({
+  ctas: [
+    {
+      text: "Get Started — Install a Skill",
+      href: "/docs",
+      variant: "primary",
+    },
+    {
+      text: "What are Skills?",
+      href: "/what-are-claude-code-skills",
+      variant: "secondary",
+    },
+  ],
+  internalLinks: [
+    {
+      text: "Learn what skills are and how they work",
+      href: "/what-are-claude-code-skills",
+      context:
+        "Understand how skills extend Claude Code with reusable prompts and workflows.",
+    },
+    {
+      text: "Follow the getting started guide",
+      href: "/docs",
+      context:
+        "Install and configure your first skill in under two minutes.",
+    },
+    {
+      text: "Sign in to sync skills across devices",
+      href: "/login",
+      context:
+        "Create an account to keep your skills in sync everywhere you work.",
+    },
+  ],
+  breadcrumbs: [
+    { label: "Home", href: "/" },
+    { label: "Skills", href: "/skills" },
+  ],
+  nextSteps: [
+    {
+      text: "Read the installation guide",
+      href: "/docs",
+      variant: "primary",
+    },
+    {
+      text: "Learn about skills",
+      href: "/what-are-claude-code-skills",
+      variant: "secondary",
+    },
+  ],
+});
+
+/**
+ * What are Claude Code Skills page engagement data — CTA to /skills catalog
+ */
+export const whatAreSkillsPageEngagement = (): PageEngagement => ({
+  ctas: [
+    {
+      text: "Browse the Skill Catalog",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Read the Docs",
+      href: "/docs",
+      variant: "secondary",
+    },
+  ],
+  internalLinks: [
+    {
+      text: "Browse available skills",
+      href: "/skills",
+      context:
+        "See all ready-to-install skills including linting, git workflows, and code review.",
+    },
+    {
+      text: "Get started with installation",
+      href: "/docs",
+      context:
+        "Follow the step-by-step guide to install your first skill.",
+    },
+    {
+      text: "View open source foundations",
+      href: "/open-source",
+      context:
+        "Explore the open source libraries that make Skill Manager possible.",
+    },
+  ],
+  breadcrumbs: [
+    { label: "Home", href: "/" },
+    { label: "What are Skills?", href: "/what-are-claude-code-skills" },
+  ],
+  nextSteps: [
+    {
+      text: "Explore the skill catalog",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Start installing skills",
+      href: "/docs",
+      variant: "secondary",
+    },
+  ],
+});
+
+/**
+ * Docs page engagement data
+ */
+export const docsPageEngagement = (): PageEngagement => ({
+  ctas: [
+    {
+      text: "Browse the Skill Catalog",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Sign In to Sync",
+      href: "/login",
+      variant: "secondary",
+    },
+  ],
+  internalLinks: [
+    {
+      text: "Browse the skill catalog",
+      href: "/skills",
+      context:
+        "Find the right skill for your workflow — linting, formatting, git, and more.",
+    },
+    {
+      text: "Learn what skills are",
+      href: "/what-are-claude-code-skills",
+      context:
+        "Understand how skills work under the hood.",
+    },
+    {
+      text: "Sign in to sync across devices",
+      href: "/login",
+      context:
+        "Keep your skills in sync everywhere you work.",
+    },
+  ],
+  breadcrumbs: [
+    { label: "Home", href: "/" },
+    { label: "Docs", href: "/docs" },
+  ],
+  nextSteps: [
+    {
+      text: "Find a skill to install",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Create an account",
+      href: "/login",
+      variant: "secondary",
+    },
+  ],
+});
+
+/**
+ * Open source page engagement data
+ */
+export const openSourcePageEngagement = (): PageEngagement => ({
+  ctas: [
+    {
+      text: "Browse Skills Built with These Libraries",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "View on GitHub",
+      href: "https://github.com/a14a-org/claudeskill-manager",
+      variant: "secondary",
+    },
+  ],
+  internalLinks: [
+    {
+      text: "Browse the skill catalog",
+      href: "/skills",
+      context:
+        "See the skills built on top of these open source foundations.",
+    },
+    {
+      text: "Get started with the docs",
+      href: "/docs",
+      context:
+        "Learn how to install and use skills in your workflow.",
+    },
+  ],
+  breadcrumbs: [
+    { label: "Home", href: "/" },
+    { label: "Open Source", href: "/open-source" },
+  ],
+  nextSteps: [
+    {
+      text: "Explore the skill catalog",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Read the docs",
+      href: "/docs",
+      variant: "secondary",
+    },
+  ],
+});
+
+/**
+ * Login page engagement data
+ */
+export const loginPageEngagement = (): PageEngagement => ({
+  ctas: [
+    {
+      text: "Browse Skills First",
+      href: "/skills",
+      variant: "secondary",
+    },
+  ],
+  internalLinks: [
+    {
+      text: "Learn what skills are",
+      href: "/what-are-claude-code-skills",
+      context:
+        "Not sure what this is about? Learn how skills work first.",
+    },
+    {
+      text: "Browse available skills",
+      href: "/skills",
+      context:
+        "See the catalog of ready-to-install skills before signing in.",
+    },
+  ],
+  breadcrumbs: [
+    { label: "Home", href: "/" },
+    { label: "Sign In", href: "/login" },
+  ],
+  nextSteps: [
+    {
+      text: "Browse the skill catalog",
+      href: "/skills",
+      variant: "primary",
+    },
+    {
+      text: "Read the docs",
+      href: "/docs",
+      variant: "secondary",
+    },
+  ],
+});
+
+/**
+ * Navigation structure for the site — used by the frontend to render
+ * consistent nav with current-page highlighting and key conversion paths.
+ */
+export const siteNavigation = (): {
+  primary: { label: string; href: string }[];
+  quickStart: { label: string; href: string; description: string }[];
+} => ({
+  primary: [
+    { label: "Home", href: "/" },
+    { label: "Skills", href: "/skills" },
+    { label: "Docs", href: "/docs" },
+    { label: "What are Skills?", href: "/what-are-claude-code-skills" },
+    { label: "Open Source", href: "/open-source" },
+  ],
+  quickStart: [
+    {
+      label: "Browse Skills",
+      href: "/skills",
+      description: "Discover reusable prompts and workflows",
+    },
+    {
+      label: "Get Started",
+      href: "/docs",
+      description: "Install your first skill in under 2 minutes",
+    },
+    {
+      label: "Sign In",
+      href: "/login",
+      description: "Sync skills across all your devices",
+    },
+  ],
+});

--- a/packages/server/src/routes/jsonld.ts
+++ b/packages/server/src/routes/jsonld.ts
@@ -17,54 +17,88 @@ import {
   openSourceCollectionSchema,
   loginWebPageSchema,
   webPageSchema,
+  breadcrumbSchema,
+  siteNavigationSchema,
 } from "../jsonld.js";
+
+const SITE_URL = "https://claudeskill.io";
 
 export const jsonldRouter = new Hono();
 
 /**
- * Homepage JSON-LD: Organization + WebSite with SearchAction
+ * Homepage JSON-LD: Organization + WebSite + SiteNavigation + breadcrumbs
  * GET /jsonld/home
  */
 jsonldRouter.get("/home", (c) => {
   return c.json([
     organizationSchema(),
     webSiteSchema(),
+    siteNavigationSchema(),
     webPageSchema(
       "Claude Skill Manager - Sync Claude Code Skills Across Devices & Teams",
       "Keep your prompts and workflows in sync everywhere you work. Install skills with one command, share with your team, and never lose your setup again.",
       "/"
     ),
+    breadcrumbSchema([{ name: "Home", url: SITE_URL }]),
   ]);
 });
 
 /**
- * Skills page JSON-LD: CollectionPage with ItemList
+ * Skills page JSON-LD: CollectionPage with ItemList + breadcrumbs
  * GET /jsonld/skills
  */
 jsonldRouter.get("/skills", (c) => {
-  return c.json([skillsItemListSchema()]);
+  return c.json([
+    skillsItemListSchema(),
+    breadcrumbSchema([
+      { name: "Home", url: SITE_URL },
+      { name: "Skills", url: `${SITE_URL}/skills` },
+    ]),
+  ]);
 });
 
 /**
- * What are Claude Code Skills page JSON-LD: Article + FAQPage
+ * What are Claude Code Skills page JSON-LD: Article + FAQPage + breadcrumbs
  * GET /jsonld/what-are-claude-code-skills
  */
 jsonldRouter.get("/what-are-claude-code-skills", (c) => {
-  return c.json([articleSchema(), faqSchema()]);
+  return c.json([
+    articleSchema(),
+    faqSchema(),
+    breadcrumbSchema([
+      { name: "Home", url: SITE_URL },
+      {
+        name: "What are Claude Code Skills?",
+        url: `${SITE_URL}/what-are-claude-code-skills`,
+      },
+    ]),
+  ]);
 });
 
 /**
- * Open Source page JSON-LD: CollectionPage
+ * Open Source page JSON-LD: CollectionPage + breadcrumbs
  * GET /jsonld/open-source
  */
 jsonldRouter.get("/open-source", (c) => {
-  return c.json([openSourceCollectionSchema()]);
+  return c.json([
+    openSourceCollectionSchema(),
+    breadcrumbSchema([
+      { name: "Home", url: SITE_URL },
+      { name: "Open Source", url: `${SITE_URL}/open-source` },
+    ]),
+  ]);
 });
 
 /**
- * Login page JSON-LD: WebPage
+ * Login page JSON-LD: WebPage + breadcrumbs
  * GET /jsonld/login
  */
 jsonldRouter.get("/login", (c) => {
-  return c.json([loginWebPageSchema()]);
+  return c.json([
+    loginWebPageSchema(),
+    breadcrumbSchema([
+      { name: "Home", url: SITE_URL },
+      { name: "Sign In", url: `${SITE_URL}/login` },
+    ]),
+  ]);
 });

--- a/packages/server/src/routes/pages.ts
+++ b/packages/server/src/routes/pages.ts
@@ -1,0 +1,78 @@
+/**
+ * Page engagement routes
+ *
+ * Serves CTA, internal linking, breadcrumb, and navigation data
+ * for each page so the frontend can render engagement elements.
+ *
+ * GET /pages/:page returns engagement data for that page.
+ * GET /pages/navigation returns the site navigation structure.
+ */
+
+import { Hono } from "hono";
+import {
+  homePageEngagement,
+  skillsPageEngagement,
+  whatAreSkillsPageEngagement,
+  docsPageEngagement,
+  openSourcePageEngagement,
+  loginPageEngagement,
+  siteNavigation,
+} from "../pages.js";
+
+export const pagesRouter = new Hono();
+
+/**
+ * Homepage engagement data
+ * GET /pages/home
+ */
+pagesRouter.get("/home", (c) => {
+  return c.json(homePageEngagement());
+});
+
+/**
+ * Skills page engagement data
+ * GET /pages/skills
+ */
+pagesRouter.get("/skills", (c) => {
+  return c.json(skillsPageEngagement());
+});
+
+/**
+ * What are Claude Code Skills page engagement data
+ * GET /pages/what-are-claude-code-skills
+ */
+pagesRouter.get("/what-are-claude-code-skills", (c) => {
+  return c.json(whatAreSkillsPageEngagement());
+});
+
+/**
+ * Docs page engagement data
+ * GET /pages/docs
+ */
+pagesRouter.get("/docs", (c) => {
+  return c.json(docsPageEngagement());
+});
+
+/**
+ * Open source page engagement data
+ * GET /pages/open-source
+ */
+pagesRouter.get("/open-source", (c) => {
+  return c.json(openSourcePageEngagement());
+});
+
+/**
+ * Login page engagement data
+ * GET /pages/login
+ */
+pagesRouter.get("/login", (c) => {
+  return c.json(loginPageEngagement());
+});
+
+/**
+ * Site navigation structure
+ * GET /pages/navigation
+ */
+pagesRouter.get("/navigation", (c) => {
+  return c.json(siteNavigation());
+});


### PR DESCRIPTION
## Summary

**Domain:** claudeskill.io
**Category:** engagement

Add prominent CTAs on the homepage directing users to /skills (the second most visited page) and /docs. Add internal linking between related pages — e.g., /what-are-claude-code-skills should link to /skills, and /skills should link to /docs for getting started. Consider adding an 'above the fold' quick-start section on the homepage that funnels users to the skills catalog or documentation.

## Rationale

The homepage gets 37 of 74 pageviews (50%), but the bounce rate is 68.3% with an average session time of only 22 seconds. Users are landing and leaving without exploring. The /skills page only gets 7 views despite being the core product page — that's an 81% drop-off from homepage. /docs only got 1 view, suggesting users can't easily find or aren't motivated to read documentation. Better internal linking and CTAs can convert homepage visitors into engaged users.

## Expected Impact

Reducing bounce rate by 10-15 percentage points and increasing pages-per-session from 1.9 to 2.5+. More visitors reaching /skills and /docs means higher chance of conversion to actual users. Session time should increase from 22s to 40s+.

## Data Points

- Bounce rate: 68.3%
- Average session time: only 22 seconds
- Homepage: 37 views vs /skills: 7 views (81% drop-off)
- /docs: only 1 view in the entire period
- 74 total pageviews across 38 visitors = ~1.9 pages per session

## Build & Lint

```
Build: FAIL
• Packages in scope: @claude-skill-sync/server, @claudeskill/cli, @claudeskill/core
• Running build in 3 packages
• Remote caching disabled
@claudeskill/core:build: cache miss, executing b86b8194558d5c5c
@claude-skill-sync/server:build: cache miss, executing 50171d6a57fa480b
@claude-skill-sync/server:build: yarn run v1.22.22
@claudeskill/core:build: yarn run v1.22.22
@claudeskill/core:build: $ tsc
@claude-skill-sync/server:build: $ tsc
@claudeskill/core:build: src/crypto.ts(11,26): error TS2307: Cannot find module '@noble/hashes/argon2' or its corresponding type declarations.
@claudeskill/core:build: error Command failed with exit code 2.
@claudeskill/core:build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

 Tasks:    0 successful, 2 total
Cached:    0 cached, 2 total
  Time:    1.322s 
Failed:    @claudeskill/core#build


$ turbo build
• turbo 2.7.2
@claudeskill/core:build: ERROR: command finished with error: command (/private/var/folders/nh/8q

Lint: FAIL
• Packages in scope: @claude-skill-sync/server, @claudeskill/cli, @claudeskill/core
• Running lint in 3 packages
• Remote caching disabled
@claudeskill/core:build: cache miss, executing b86b8194558d5c5c
@claudeskill/core:build: yarn run v1.22.22
@claudeskill/core:build: $ tsc
@claudeskill/core:build: src/crypto.ts(11,26): error TS2307: Cannot find module '@noble/hashes/argon2' or its corresponding type declarations.
@claudeskill/core:build: error Command failed with exit code 2.
@claudeskill/core:build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

 Tasks:    0 successful, 1 total
Cached:    0 cached, 1 total
  Time:    595ms 
Failed:    @claudeskill/core#build


$ turbo lint
• turbo 2.7.2
@claudeskill/core:build: ERROR: command finished with error: command (/private/var/folders/nh/8q2nxb5573j12ljdzsy59q500000gn/T/scalarops-auto/improve-engagement-20260215-u5ye/packages/core) /Users/dafmulder/.nvm/versions/node/v24.12.0/b
```

## Visual Regression Results

> Visual regression skipped: Could not start local server — skipping visual regression

---

*Generated by [ScalarOps AI](https://github.com/a14a-org/scalarops-ai) - Autonomous Website Improvement Workforce*