### PR TITLE
Add production-ready team sharing rollout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ PORT=3001
 # Node environment (development | production)
 NODE_ENV=development
 
+# Enable team sharing routes (false for dark launch, true to expose /teams)
+ENABLE_TEAM_SHARING=false
+
 # PostgreSQL connection string
 DATABASE_URL=postgres://user:password@localhost:5432/skillsync
 

--- a/COOLIFY_RELEASE_CHECKLIST.md
+++ b/COOLIFY_RELEASE_CHECKLIST.md
@@ -1,0 +1,17 @@
+# Coolify Release Checklist
+
+1. Confirm `DATABASE_URL` is set for the API resource.
+2. Set `ENABLE_TEAM_SHARING=false`.
+3. Back up production Postgres.
+4. Run:
+
+```bash
+psql "$DATABASE_URL" -f packages/server/drizzle/prod/20260311_team_share_incremental.sql
+```
+
+5. Deploy from `docker-compose.yaml`.
+6. Verify `/health` and normal personal sync.
+7. Set `ENABLE_TEAM_SHARING=true`.
+8. Redeploy.
+9. Run the two-account smoke test for team create, invite, accept, key distribution, and removal.
+10. Publish the CLI update only after the server smoke test passes.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Coolify Deployment Guide
 
-Deploy Claude Skill Sync server to Coolify.
+Deploy Claude Skill Sync server to Coolify with PostgreSQL and an optional dark launch for team sharing.
 
 ## Prerequisites
 
@@ -33,6 +33,7 @@ Add these environment variables in Coolify:
 
 ```
 # Required
+DATABASE_URL=<postgres-connection-string>
 JWT_SECRET=<generate-a-random-64-char-string>
 
 # Email (Resend)
@@ -42,6 +43,7 @@ FROM_EMAIL=noreply@claudeskill.io
 # Optional
 NODE_ENV=production
 PORT=3001
+ENABLE_TEAM_SHARING=false
 ```
 
 ### Generate JWT_SECRET
@@ -67,16 +69,24 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 3. Enable **HTTPS** (Let's Encrypt)
 4. Set port mapping: `3001`
 
-## Step 5: Configure Persistent Storage
+## Step 5: Apply the Production Migration
 
-The SQLite database needs persistent storage:
+Before the first deploy containing team sharing:
 
-1. Go to **Storages** in Coolify
-2. Add a volume:
-   - **Name**: `claude-skill-sync-data`
-   - **Mount Path**: `/app/data`
+```bash
+psql "$DATABASE_URL" -f packages/server/drizzle/prod/20260311_team_share_incremental.sql
+```
+
+This script is designed for the existing live schema. Do not use the generated baseline migration as your first production migration.
 
 ## Step 6: Deploy
+
+Recommended sequence:
+
+1. Deploy once with `ENABLE_TEAM_SHARING=false`
+2. Verify existing login, push, and pull still work
+3. Set `ENABLE_TEAM_SHARING=true`
+4. Redeploy
 
 1. Click **Deploy**
 2. Wait for build to complete
@@ -104,7 +114,9 @@ Check if Node.js version is correct. The server requires Node 20.6+.
 
 ### Database Errors
 
-Ensure the `/app/data` volume is mounted and writable.
+1. Verify `DATABASE_URL` is set correctly
+2. Ensure PostgreSQL is reachable from the Coolify host
+3. Confirm the incremental SQL migration has been applied
 
 ### Email Not Sending
 
@@ -128,7 +140,7 @@ If you prefer not to use Docker Compose, create a new resource with:
 | Dockerfile Location | `packages/server/Dockerfile` |
 | Base Directory | `/` |
 
-Then configure the same environment variables and storage.
+Then configure the same environment variables.
 
 ## Updating
 

--- a/PROD_ROLLOUT.md
+++ b/PROD_ROLLOUT.md
@@ -1,0 +1,58 @@
+# Production Rollout
+
+Use this sequence when shipping the team-sharing server changes and the CLI update.
+
+## 1. Back up production
+
+Take a verified PostgreSQL backup before applying the migration.
+
+## 2. Apply the incremental migration
+
+```bash
+psql "$DATABASE_URL" -f packages/server/drizzle/prod/20260311_team_share_incremental.sql
+```
+
+This script is intended for the existing live schema. Do not use the generated Drizzle baseline as your first production migration.
+
+## 3. Deploy the server dark
+
+Set:
+
+```env
+ENABLE_TEAM_SHARING=false
+```
+
+Then deploy the server.
+
+## 4. Verify existing behavior
+
+Check:
+- `GET /health` returns `200`
+- login still works
+- personal push works
+- personal pull works
+
+## 5. Enable team routes
+
+Set:
+
+```env
+ENABLE_TEAM_SHARING=true
+```
+
+Redeploy the server.
+
+## 6. Smoke test team sharing
+
+Use two internal accounts and verify:
+- team create
+- invite existing user
+- accept invite
+- owner distributes team key
+- invitee can fetch and decrypt the team key
+- owner can remove a member with key rotation payload
+- removed member cannot decrypt future writes
+
+## 7. Publish the CLI update
+
+Only publish the CLI after the server migration and smoke test succeed.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Sync your Claude Code skills across devices with zero-knowledge encryption.
 
 - **Zero-knowledge encryption** - Your skills are encrypted client-side. The server never sees your content.
 - **Cross-device sync** - Access your skills from any device
+- **Team sharing** - Share encrypted skills with colleagues using per-member key envelopes
 - **Self-host option** - Run your own server for complete control
 - **Simple CLI** - Easy to use command-line interface
 
@@ -35,6 +36,8 @@ claudeskill push               # Push local skills to cloud
 claudeskill pull               # Pull skills from cloud
 claudeskill login              # Login to existing account
 claudeskill logout             # Logout and clear credentials
+claudeskill team list          # List your teams
+claudeskill team create <name> # Create a team workspace
 claudeskill --help             # Show all commands
 ```
 
@@ -79,8 +82,8 @@ claude-skill-sync/
 │   ├── cli/            # Command-line interface
 │   └── server/         # API server
 ├── .env.example        # Environment variables template
-├── docker-compose.yml  # Self-hosting setup
-└── PLAN.md            # Architecture documentation
+├── docker-compose.yaml # Self-hosting setup
+└── packages/server/drizzle/prod/20260311_team_share_incremental.sql
 ```
 
 ## Self-Hosting
@@ -93,7 +96,7 @@ cp .env.example .env
 # Edit .env - set JWT_SECRET and optionally RESEND_API_KEY
 
 # Start the server
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Manual Setup
@@ -116,10 +119,28 @@ node packages/server/dist/index.js
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `PORT` | No | Server port (default: 3001) |
-| `DATABASE_PATH` | No | SQLite database path (default: ./data/skills.db) |
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `ENABLE_TEAM_SHARING` | No | Exposes `/teams` when set to `true` |
 | `JWT_SECRET` | Yes | Secret for JWT signing. Generate with `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` |
 | `RESEND_API_KEY` | No | Resend API key for OTP emails. Leave empty in dev (codes logged to console) |
 | `FROM_EMAIL` | No | From address for emails (default: noreply@claudeskill.io) |
+
+## Production Rollout
+
+For an already-live server, use the manual incremental migration instead of the generated Drizzle baseline:
+
+```bash
+psql "$DATABASE_URL" -f packages/server/drizzle/prod/20260311_team_share_incremental.sql
+```
+
+Recommended order:
+1. Back up production Postgres.
+2. Apply `packages/server/drizzle/prod/20260311_team_share_incremental.sql`.
+3. Deploy the server with `ENABLE_TEAM_SHARING=false`.
+4. Verify existing personal sync still works.
+5. Redeploy with `ENABLE_TEAM_SHARING=true`.
+6. Smoke test team create, invite, accept, key distribution, and member removal.
+7. Publish the CLI update after that.
 
 ## How It Works
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,12 +10,11 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
-      - DATABASE_PATH=/app/data/skills.db
+      - ENABLE_TEAM_SHARING=${ENABLE_TEAM_SHARING:-false}
+      - DATABASE_URL=${DATABASE_URL}
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production}
       - RESEND_API_KEY=${RESEND_API_KEY:-}
       - FROM_EMAIL=${FROM_EMAIL:-noreply@claudeskill.io}
-    volumes:
-      - ./data:/app/data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3001/health"]
@@ -23,6 +22,3 @@ services:
       timeout: 3s
       retries: 3
       start_period: 5s
-
-volumes:
-  data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,21 @@
         "hono": "^4"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -483,6 +498,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -587,6 +603,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
       "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -685,6 +702,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -901,6 +919,20 @@
         "turbo-windows-arm64": "2.7.2"
       }
     },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.7.2.tgz",
+      "integrity": "sha512-dxY3X6ezcT5vm3coK6VGixbrhplbQMwgNsCsvZamS/+/6JiebqW9DKt4NwpgYXhDY2HdH00I7FWs3wkVuan4rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/turbo-darwin-arm64": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.7.2.tgz",
@@ -913,6 +945,62 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.7.2.tgz",
+      "integrity": "sha512-kP+TiiMaiPugbRlv57VGLfcjFNsFbo8H64wMBCPV2270Or2TpDCBULMzZrvEsvWFjT3pBFvToYbdp8/Kw0jAQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.7.2.tgz",
+      "integrity": "sha512-VDJwQ0+8zjAfbyY6boNaWfP6RIez4ypKHxwkuB6SrWbOSk+vxTyW5/hEjytTwK8w/TsbKVcMDyvpora8tEsRFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.7.2.tgz",
+      "integrity": "sha512-rPjqQXVnI6A6oxgzNEE8DNb6Vdj2Wwyhfv3oDc+YM3U9P7CAcBIlKv/868mKl4vsBtz4ouWpTQNXG8vljgJO+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.7.2.tgz",
+      "integrity": "sha512-tcnHvBhO515OheIFWdxA+qUvZzNqqcHbLVFc1+n+TJ1rrp8prYicQtbtmsiKgMvr/54jb9jOabU62URAobnB7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/typescript": {
@@ -974,7 +1062,9 @@
     "packages/core": {
       "name": "@claudeskill/core",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
+        "@noble/curves": "^1.8.0",
         "@noble/hashes": "^1.7.1"
       },
       "devDependencies": {
@@ -984,6 +1074,7 @@
     "packages/server": {
       "name": "@claude-skill-sync/server",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "@noble/hashes": "^1.7.1",

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -251,6 +251,31 @@ export const setMasterKey = async (
   });
 };
 
+export type SharingKeyResponse = {
+  hasKeypair: boolean;
+  publicKey?: string;
+  publicKeyFingerprint?: string | null;
+  encryptedPrivateKey?: string;
+  privateKeyIv?: string;
+  privateKeyTag?: string;
+};
+
+export const getSharingKey = async (): Promise<ApiResponse<SharingKeyResponse>> => {
+  return apiRequest("/account/sharing-key");
+};
+
+export const setSharingKey = async (
+  publicKey: string,
+  encryptedPrivateKey: string,
+  privateKeyIv: string,
+  privateKeyTag: string
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest("/account/sharing-key", {
+    method: "PUT",
+    body: JSON.stringify({ publicKey, encryptedPrivateKey, privateKeyIv, privateKeyTag }),
+  });
+};
+
 // =============================================================================
 // Blobs API
 // =============================================================================
@@ -438,4 +463,390 @@ export const checkHealth = async (): Promise<ApiResponse<HealthResponse>> => {
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : "Network error", status: 0 };
   }
+};
+
+// =============================================================================
+// Teams API
+// =============================================================================
+
+export type TeamListItem = {
+  id: string;
+  name: string;
+  role: string;
+  status: string;
+  memberCount: number;
+  skillCount: number;
+  activeKeyVersion: number;
+  createdAt: string;
+};
+
+export type TeamListResponse = {
+  teams: TeamListItem[];
+};
+
+export const listTeams = async (): Promise<ApiResponse<TeamListResponse>> => {
+  return apiRequest("/teams");
+};
+
+export type TeamCreateResponse = {
+  id: string;
+  name: string;
+  role: string;
+  status: string;
+  activeKeyVersion?: number;
+  createdAt: string;
+};
+
+export const createTeam = async (name: string): Promise<ApiResponse<TeamCreateResponse>> => {
+  return apiRequest("/teams", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+};
+
+export type TeamMemberItem = {
+  userId: string;
+  email: string;
+  role: string;
+  status: string;
+  hasTeamKey: boolean;
+  publicKeyFingerprint?: string | null;
+  createdAt: string;
+};
+
+export type TeamSkillItem = {
+  id: string;
+  skillKey: string;
+  currentHash: string | null;
+  updatedAt: string;
+};
+
+export type TeamDetailResponse = {
+  id: string;
+  name: string;
+  role: string;
+  status: string;
+  members: TeamMemberItem[];
+  skills: TeamSkillItem[];
+  activeKeyVersion?: number;
+  createdAt: string;
+};
+
+export const getTeam = async (teamId: string): Promise<ApiResponse<TeamDetailResponse>> => {
+  return apiRequest(`/teams/${teamId}`);
+};
+
+export const updateTeam = async (
+  teamId: string,
+  name: string
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}`, {
+    method: "PUT",
+    body: JSON.stringify({ name }),
+  });
+};
+
+export const deleteTeam = async (teamId: string): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}`, {
+    method: "DELETE",
+  });
+};
+
+// Team Members
+export type TeamMembersResponse = {
+  members: TeamMemberItem[];
+};
+
+export const listTeamMembers = async (
+  teamId: string
+): Promise<ApiResponse<TeamMembersResponse>> => {
+  return apiRequest(`/teams/${teamId}/members`);
+};
+
+export const updateTeamMemberRole = async (
+  teamId: string,
+  userId: string,
+  role: string
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}/members/${userId}`, {
+    method: "PUT",
+    body: JSON.stringify({ role }),
+  });
+};
+
+export const removeTeamMember = async (
+  teamId: string,
+  userId: string,
+  nextTeamKeyVersion: number,
+  envelopes: Array<{
+    recipientUserId: string;
+    encryptedTeamKey: string;
+    iv: string;
+    tag: string;
+    ephemeralPublicKey: string;
+  }>
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}/members/${userId}`, {
+    method: "DELETE",
+    body: JSON.stringify({ nextTeamKeyVersion, envelopes }),
+  });
+};
+
+export type PendingMemberItem = {
+  userId: string;
+  email: string;
+  role: string;
+  publicKey: string | null;
+  publicKeyFingerprint: string | null;
+  createdAt: string;
+};
+
+export type PendingMembersResponse = {
+  pendingMembers: PendingMemberItem[];
+};
+
+export const listPendingMembers = async (
+  teamId: string
+): Promise<ApiResponse<PendingMembersResponse>> => {
+  return apiRequest(`/teams/${teamId}/members/pending`);
+};
+
+export type AllPendingMemberItem = PendingMemberItem & {
+  teamId: string;
+  teamName: string;
+};
+
+export type AllPendingMembersResponse = {
+  pendingMembers: AllPendingMemberItem[];
+};
+
+export const listAllPendingMembers = async (): Promise<ApiResponse<AllPendingMembersResponse>> => {
+  return apiRequest("/teams/pending-members");
+};
+
+export const distributeTeamKey = async (
+  teamId: string,
+  userId: string,
+  encryptedTeamKey: string,
+  iv: string,
+  tag: string,
+  ephemeralPublicKey: string,
+  teamKeyVersion?: number
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}/members/${userId}/key`, {
+    method: "POST",
+    body: JSON.stringify({
+      encryptedTeamKey,
+      iv,
+      tag,
+      ephemeralPublicKey,
+      teamKeyVersion,
+    }),
+  });
+};
+
+export type MyTeamKeyResponse = {
+  encryptedTeamKey: string;
+  iv: string;
+  tag: string;
+  ephemeralPublicKey: string;
+  teamKeyVersion: number;
+  status: string;
+};
+
+export const getMyTeamKey = async (teamId: string): Promise<ApiResponse<MyTeamKeyResponse>> => {
+  return apiRequest(`/teams/${teamId}/my-key`);
+};
+
+// Team Invites
+export type TeamInviteItem = {
+  id: string;
+  email: string;
+  role: string;
+  expiresAt: string;
+  usedAt: string | null;
+  createdAt: string;
+};
+
+export type TeamInvitesResponse = {
+  invites: TeamInviteItem[];
+};
+
+export const listTeamInvites = async (
+  teamId: string
+): Promise<ApiResponse<TeamInvitesResponse>> => {
+  return apiRequest(`/teams/${teamId}/invites`);
+};
+
+export type CreateInviteResponse = {
+  id: string;
+  token: string;
+  email: string;
+  role: string;
+  expiresAt: string;
+};
+
+export const createTeamInvite = async (
+  teamId: string,
+  email: string,
+  role: string
+): Promise<ApiResponse<CreateInviteResponse>> => {
+  return apiRequest(`/teams/${teamId}/invites`, {
+    method: "POST",
+    body: JSON.stringify({ email, role }),
+  });
+};
+
+export const deleteTeamInvite = async (
+  teamId: string,
+  inviteId: string
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}/invites/${inviteId}`, {
+    method: "DELETE",
+  });
+};
+
+export type AcceptInviteResponse = {
+  teamId: string;
+  teamName: string;
+  role: string;
+  status: string;
+  message: string;
+};
+
+export const acceptTeamInvite = async (
+  token: string
+): Promise<ApiResponse<AcceptInviteResponse>> => {
+  return apiRequest("/teams/invites/accept", {
+    method: "POST",
+    body: JSON.stringify({ token }),
+  });
+};
+
+export type PendingInviteItem = {
+  id: string;
+  teamId: string;
+  teamName: string;
+  role: string;
+  expiresAt: string;
+  createdAt: string;
+};
+
+export type PendingInvitesResponse = {
+  invites: PendingInviteItem[];
+};
+
+export const listMyPendingInvites = async (): Promise<ApiResponse<PendingInvitesResponse>> => {
+  return apiRequest("/teams/invites/pending");
+};
+
+// User Keypair
+export type KeypairResponse = {
+  hasKeypair: boolean;
+  publicKey?: string;
+  publicKeyFingerprint?: string | null;
+  encryptedPrivateKey?: string;
+  privateKeyIv?: string;
+  privateKeyTag?: string;
+};
+
+export const getKeypair = async (): Promise<ApiResponse<KeypairResponse>> => {
+  return apiRequest("/teams/keypair");
+};
+
+export const setKeypair = async (
+  publicKey: string,
+  encryptedPrivateKey: string,
+  privateKeyIv: string,
+  privateKeyTag: string
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest("/teams/keypair", {
+    method: "PUT",
+    body: JSON.stringify({ publicKey, encryptedPrivateKey, privateKeyIv, privateKeyTag }),
+  });
+};
+
+// Team Skills
+export type TeamSkillListResponse = {
+  skills: TeamSkillItem[];
+};
+
+export const listTeamSkills = async (
+  teamId: string
+): Promise<ApiResponse<TeamSkillListResponse>> => {
+  return apiRequest(`/teams/${teamId}/skills`);
+};
+
+export type TeamSkillResponse = {
+  skillKey: string;
+  skillId: string;
+  hash: string;
+  encryptedData: string;
+  iv: string;
+  tag: string;
+  teamKeyVersion: number;
+  parentHash: string | null;
+  message: string | null;
+  createdAt: string;
+};
+
+export const getTeamSkill = async (
+  teamId: string,
+  skillKey: string
+): Promise<ApiResponse<TeamSkillResponse>> => {
+  return apiRequest(`/teams/${teamId}/skills/${encodeURIComponent(skillKey)}`);
+};
+
+export type TeamSkillVersionInfo = {
+  hash: string;
+  teamKeyVersion: number;
+  parentHash: string | null;
+  message: string | null;
+  createdAt: string;
+};
+
+export type TeamSkillVersionsResponse = {
+  skillKey: string;
+  currentHash: string | null;
+  versions: TeamSkillVersionInfo[];
+};
+
+export const getTeamSkillVersions = async (
+  teamId: string,
+  skillKey: string
+): Promise<ApiResponse<TeamSkillVersionsResponse>> => {
+  return apiRequest(`/teams/${teamId}/skills/${encodeURIComponent(skillKey)}/versions`);
+};
+
+export type PushTeamSkillResponse = {
+  skillId: string;
+  hash: string;
+  teamKeyVersion: number;
+  parentHash: string | null;
+  createdAt: string;
+};
+
+export const pushTeamSkillVersion = async (
+  teamId: string,
+  skillKey: string,
+  hash: string,
+  encryptedData: string,
+  iv: string,
+  tag: string,
+  teamKeyVersion: number,
+  message: string | undefined
+): Promise<ApiResponse<PushTeamSkillResponse>> => {
+  return apiRequest(`/teams/${teamId}/skills/${encodeURIComponent(skillKey)}/versions`, {
+    method: "POST",
+    body: JSON.stringify({ hash, encryptedData, iv, tag, teamKeyVersion, message }),
+  });
+};
+
+export const deleteTeamSkill = async (
+  teamId: string,
+  skillKey: string
+): Promise<ApiResponse<{ success: boolean }>> => {
+  return apiRequest(`/teams/${teamId}/skills/${encodeURIComponent(skillKey)}`, {
+    method: "DELETE",
+  });
 };

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -1,0 +1,489 @@
+/**
+ * Team management commands
+ */
+
+import * as p from "@clack/prompts";
+import {
+  listTeams,
+  createTeam,
+  getTeam,
+  createTeamInvite,
+  acceptTeamInvite,
+  listAllPendingMembers,
+  distributeTeamKey,
+  getSharingKey,
+  setSharingKey,
+  getKeypair,
+  setKeypair,
+  getMyTeamKey,
+} from "../api.js";
+import { loadCredentials, saveCredentials } from "../credentials.js";
+import {
+  computeKeyFingerprint,
+  generateX25519KeyPair,
+  encryptTeamKeyForMember,
+  decryptTeamKeyAsMember,
+  generateTeamKey,
+  encrypt,
+  decrypt,
+  toBase64,
+  fromBase64,
+} from "@claudeskill/core";
+
+/**
+ * Ensure user has a keypair for team operations
+ * Generates one if not present
+ */
+const ensureKeypair = async (
+  masterKey: Uint8Array
+): Promise<{ publicKey: Uint8Array; privateKey: Uint8Array }> => {
+  const credentials = await loadCredentials();
+  if (!credentials) {
+    throw new Error("Not logged in");
+  }
+
+  // Check if we have a local keypair
+  if (
+    credentials.publicKey &&
+    credentials.encryptedPrivateKey &&
+    credentials.privateKeyIv &&
+    credentials.privateKeyTag
+  ) {
+    // Decrypt private key
+    const privateKey = decrypt(
+      fromBase64(credentials.encryptedPrivateKey),
+      masterKey,
+      fromBase64(credentials.privateKeyIv),
+      fromBase64(credentials.privateKeyTag)
+    );
+    return {
+      publicKey: fromBase64(credentials.publicKey),
+      privateKey,
+    };
+  }
+
+  // Check server for existing keypair
+  const serverKeypair = await getSharingKey();
+  const legacyServerKeypair =
+    !serverKeypair.ok && serverKeypair.status === 404 ? await getKeypair() : null;
+  const keypairResponse =
+    serverKeypair.ok || serverKeypair.status !== 404
+      ? serverKeypair
+      : legacyServerKeypair;
+  if (keypairResponse?.ok && keypairResponse.data.hasKeypair) {
+    // Download and decrypt
+    const privateKey = decrypt(
+      fromBase64(keypairResponse.data.encryptedPrivateKey!),
+      masterKey,
+      fromBase64(keypairResponse.data.privateKeyIv!),
+      fromBase64(keypairResponse.data.privateKeyTag!)
+    );
+
+    // Save locally
+    await saveCredentials({
+      ...credentials,
+      publicKey: keypairResponse.data.publicKey,
+      publicKeyFingerprint: keypairResponse.data.publicKeyFingerprint ?? undefined,
+      encryptedPrivateKey: keypairResponse.data.encryptedPrivateKey,
+      privateKeyIv: keypairResponse.data.privateKeyIv,
+      privateKeyTag: keypairResponse.data.privateKeyTag,
+    });
+
+    return {
+      publicKey: fromBase64(keypairResponse.data.publicKey!),
+      privateKey,
+    };
+  }
+
+  // Generate new keypair
+  p.log.info("Generating keypair for team operations...");
+  const keypair = generateX25519KeyPair();
+
+  // Encrypt private key with master key
+  const { ciphertext, iv, tag } = encrypt(keypair.privateKey, masterKey);
+
+  // Upload to server
+  const uploadResult = await setSharingKey(
+    toBase64(keypair.publicKey),
+    toBase64(ciphertext),
+    toBase64(iv),
+    toBase64(tag)
+  );
+
+  if (!uploadResult.ok) {
+    const legacyUploadResult = await setKeypair(
+      toBase64(keypair.publicKey),
+      toBase64(ciphertext),
+      toBase64(iv),
+      toBase64(tag)
+    );
+
+    if (!legacyUploadResult.ok) {
+      throw new Error(`Failed to upload keypair: ${uploadResult.error}`);
+    }
+  }
+
+  // Save locally
+  await saveCredentials({
+    ...credentials,
+    publicKey: toBase64(keypair.publicKey),
+    publicKeyFingerprint: computeKeyFingerprint(keypair.publicKey),
+    encryptedPrivateKey: toBase64(ciphertext),
+    privateKeyIv: toBase64(iv),
+    privateKeyTag: toBase64(tag),
+  });
+
+  p.log.success("Keypair generated and saved");
+
+  return keypair;
+};
+
+/**
+ * List teams command
+ */
+export const runTeamList = async (): Promise<void> => {
+  const spinner = p.spinner();
+  spinner.start("Loading teams...");
+
+  const result = await listTeams();
+
+  if (!result.ok) {
+    spinner.stop("Failed to load teams");
+    p.log.error(result.error);
+    return;
+  }
+
+  spinner.stop("Teams loaded");
+
+  if (result.data.teams.length === 0) {
+    p.log.info("You are not a member of any teams.");
+    p.log.info("Create a team with: claude-skill-sync team create <name>");
+    return;
+  }
+
+  console.log("\nYour teams:\n");
+  for (const team of result.data.teams) {
+    const status = team.status === "pending" ? " (pending key)" : "";
+    console.log(
+      `  ${team.name} [${team.role}]${status}\n` +
+        `    ID: ${team.id}\n` +
+        `    Members: ${team.memberCount} | Skills: ${team.skillCount}\n`
+    );
+  }
+};
+
+export const runTeamCreate = async (
+  name: string,
+  masterKey: Uint8Array
+): Promise<void> => {
+  const spinner = p.spinner();
+  spinner.start("Creating team and generating team key...");
+
+  const created = await createTeamWithKey(name, masterKey);
+  if (!created) {
+    spinner.stop("Failed to create team");
+    return;
+  }
+
+  spinner.stop("Team created");
+  p.log.success(`Team "${name}" created successfully!`);
+  p.log.info(`Team ID: ${created.teamId}`);
+  p.log.info("You can now invite members with: claude-skill-sync team invite <team-id> <email>");
+};
+
+/**
+ * Show team details command
+ */
+export const runTeamShow = async (teamId: string): Promise<void> => {
+  const spinner = p.spinner();
+  spinner.start("Loading team...");
+
+  const result = await getTeam(teamId);
+
+  if (!result.ok) {
+    spinner.stop("Failed to load team");
+    p.log.error(result.error);
+    return;
+  }
+
+  spinner.stop("Team loaded");
+
+  const team = result.data;
+  console.log(`\nTeam: ${team.name}`);
+  console.log(`Role: ${team.role} | Status: ${team.status}`);
+  console.log(`ID: ${team.id}\n`);
+
+  console.log("Members:");
+  for (const member of team.members) {
+    const status = member.status === "pending" ? " (pending)" : "";
+    const keyStatus = member.hasTeamKey ? "" : " [no key]";
+    console.log(`  ${member.email} [${member.role}]${status}${keyStatus}`);
+  }
+
+  if (team.skills.length > 0) {
+    console.log("\nSkills:");
+    for (const skill of team.skills) {
+      console.log(`  ${skill.skillKey} (${skill.currentHash ?? "no versions"})`);
+    }
+  } else {
+    console.log("\nNo skills shared with this team yet.");
+  }
+};
+
+/**
+ * Invite member to team
+ */
+export const runTeamInvite = async (
+  teamId: string,
+  email: string,
+  role: string = "editor"
+): Promise<void> => {
+  const validRoles = ["admin", "editor", "viewer"];
+  if (!validRoles.includes(role)) {
+    p.log.error(`Invalid role: ${role}. Must be one of: ${validRoles.join(", ")}`);
+    return;
+  }
+
+  const spinner = p.spinner();
+  spinner.start("Creating invite...");
+
+  const result = await createTeamInvite(teamId, email, role);
+
+  if (!result.ok) {
+    spinner.stop("Failed to create invite");
+    p.log.error(result.error);
+    return;
+  }
+
+  spinner.stop("Invite created");
+  p.log.success(`Invite sent to ${email} as ${role}`);
+  console.log("\nShare this invite token with the user:");
+  console.log(`\n  ${result.data.token}\n`);
+  p.log.info(`Expires: ${new Date(result.data.expiresAt).toLocaleString()}`);
+  p.log.info(
+    "They can accept with: claude-skill-sync team accept <token>"
+  );
+};
+
+/**
+ * Accept team invite
+ */
+export const runTeamAccept = async (
+  token: string,
+  masterKey: Uint8Array
+): Promise<void> => {
+  // Ensure we have a keypair first
+  await ensureKeypair(masterKey);
+
+  const spinner = p.spinner();
+  spinner.start("Accepting invite...");
+
+  const result = await acceptTeamInvite(token);
+
+  if (!result.ok) {
+    spinner.stop("Failed to accept invite");
+    p.log.error(result.error);
+    return;
+  }
+
+  spinner.stop("Invite accepted");
+  p.log.success(`Joined team "${result.data.teamName}" as ${result.data.role}`);
+  p.log.info(result.data.message);
+  p.log.info(
+    "A team admin will distribute the team key to you. Run 'sync' again later to check."
+  );
+};
+
+/**
+ * Distribute team keys to pending members
+ * This is called automatically during sync for owners/admins
+ */
+export const runDistributeKeys = async (
+  masterKey: Uint8Array,
+  teamKeys: Map<string, Uint8Array>
+): Promise<void> => {
+  const credentials = await loadCredentials();
+  if (!credentials) {
+    p.log.warning("Not logged in. Skipping team key distribution.");
+    return;
+  }
+  let knownPublicKeyFingerprints = credentials.knownPublicKeyFingerprints ?? {};
+
+  // Get all pending members across teams we manage
+  const pendingResult = await listAllPendingMembers();
+
+  if (!pendingResult.ok) {
+    p.log.warning(`Could not check for pending members: ${pendingResult.error}`);
+    return;
+  }
+
+  const pending = pendingResult.data.pendingMembers;
+  if (pending.length === 0) {
+    return;
+  }
+
+  p.log.info(`Found ${pending.length} pending team member(s) waiting for keys`);
+
+  for (const member of pending) {
+    // Check if member has a public key
+    if (!member.publicKey) {
+      p.log.warning(
+        `${member.email} hasn't set up their keypair yet. Skipping.`
+      );
+      continue;
+    }
+
+    // Get the team key (we need to have it)
+    const teamKey = teamKeys.get(member.teamId);
+    if (!teamKey) {
+      p.log.warning(
+        `You don't have the key for team "${member.teamName}". Skipping.`
+      );
+      continue;
+    }
+
+    const fingerprint =
+      member.publicKeyFingerprint ??
+      computeKeyFingerprint(fromBase64(member.publicKey));
+    const cacheKey = member.userId;
+    const cachedFingerprint = knownPublicKeyFingerprints[cacheKey];
+
+    if (cachedFingerprint && cachedFingerprint !== fingerprint) {
+      const confirm = await p.confirm({
+        message:
+          `Public key fingerprint changed for ${member.email} (${fingerprint}). Encrypt anyway?`,
+      });
+
+      if (p.isCancel(confirm) || !confirm) {
+        p.log.warning(`Skipped ${member.email} because their public key fingerprint changed.`);
+        continue;
+      }
+    } else if (!cachedFingerprint) {
+      const confirm = await p.confirm({
+        message:
+          `Trust public key for ${member.email}? Fingerprint: ${fingerprint}`,
+      });
+
+      if (p.isCancel(confirm) || !confirm) {
+        p.log.warning(`Skipped ${member.email} because their public key is not trusted yet.`);
+        continue;
+      }
+    }
+
+    // Encrypt team key for this member
+    const memberPublicKey = fromBase64(member.publicKey);
+    const encrypted = encryptTeamKeyForMember(teamKey, memberPublicKey);
+
+    // Upload encrypted key
+    const result = await distributeTeamKey(
+      member.teamId,
+      member.userId,
+      encrypted.encryptedKey,
+      encrypted.iv,
+      encrypted.tag,
+      encrypted.ephemeralPublicKey
+    );
+
+    if (result.ok) {
+      await saveCredentials({
+        ...credentials,
+        knownPublicKeyFingerprints: {
+          ...knownPublicKeyFingerprints,
+          [cacheKey]: fingerprint,
+        },
+      });
+      knownPublicKeyFingerprints = {
+        ...knownPublicKeyFingerprints,
+        [cacheKey]: fingerprint,
+      };
+      p.log.success(`Distributed team key to ${member.email} for "${member.teamName}"`);
+    } else {
+      p.log.error(`Failed to distribute key to ${member.email}: ${result.error}`);
+    }
+  }
+};
+
+/**
+ * Get team key for a team (download and decrypt if needed)
+ */
+export const getTeamKeyForTeam = async (
+  teamId: string,
+  masterKey: Uint8Array,
+  keypair: { publicKey: Uint8Array; privateKey: Uint8Array }
+): Promise<Uint8Array | null> => {
+  const result = await getMyTeamKey(teamId);
+
+  if (!result.ok) {
+    return null;
+  }
+
+  // Decrypt team key using our private key
+  const teamKey = decryptTeamKeyAsMember(
+    result.data.ephemeralPublicKey,
+    result.data.encryptedTeamKey,
+    result.data.iv,
+    result.data.tag,
+    keypair.privateKey
+  );
+
+  return teamKey;
+};
+
+/**
+ * Create a new team with initial team key
+ * Returns the team key for immediate use
+ */
+export const createTeamWithKey = async (
+  name: string,
+  masterKey: Uint8Array
+): Promise<{ teamId: string; teamKey: Uint8Array } | null> => {
+  // Ensure we have a keypair
+  const keypair = await ensureKeypair(masterKey);
+
+  // Create team
+  const createResult = await createTeam(name);
+  if (!createResult.ok) {
+    p.log.error(`Failed to create team: ${createResult.error}`);
+    return null;
+  }
+
+  // Generate team key
+  const teamKey = generateTeamKey();
+
+  // Encrypt team key for ourselves (as owner)
+  const encrypted = encryptTeamKeyForMember(teamKey, keypair.publicKey);
+
+  // Get our own user ID from team details
+  const teamDetailsResult = await getTeam(createResult.data.id);
+  if (!teamDetailsResult.ok) {
+    p.log.warning(`Team created but failed to get team details: ${teamDetailsResult.error}`);
+    return { teamId: createResult.data.id, teamKey };
+  }
+
+  const ownerMember = teamDetailsResult.data.members.find(
+    (m) => m.role === "owner"
+  );
+  if (!ownerMember) {
+    p.log.warning("Could not find owner in team members");
+    return { teamId: createResult.data.id, teamKey };
+  }
+
+  // Store our own team key
+  const keyResult = await distributeTeamKey(
+    createResult.data.id,
+    ownerMember.userId,
+    encrypted.encryptedKey,
+    encrypted.iv,
+    encrypted.tag,
+    encrypted.ephemeralPublicKey,
+    createResult.data.activeKeyVersion ?? 1
+  );
+
+  if (!keyResult.ok) {
+    p.log.warning(`Team created but failed to store team key: ${keyResult.error}`);
+  }
+
+  return { teamId: createResult.data.id, teamKey };
+};
+
+export { ensureKeypair };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,16 @@ import { runPull } from "./commands/pull.js";
 import { runLog } from "./commands/log.js";
 import { runCheckout } from "./commands/checkout.js";
 import { runDiff } from "./commands/diff.js";
+import {
+  runTeamList,
+  runTeamCreate,
+  runTeamShow,
+  runTeamInvite,
+  runTeamAccept,
+} from "./commands/team.js";
 import { loadConfig } from "./config.js";
+import { loadCredentials } from "./credentials.js";
+import { getMasterKey } from "./sync.js";
 
 const VERSION = "0.1.0";
 
@@ -44,6 +53,13 @@ Commands:
   config           Show or modify configuration
   help             Show this help message
 
+Team Commands:
+  team list                        List your teams
+  team create <name>               Create a new team
+  team show <team-id>              Show team details
+  team invite <team-id> <email> [role]  Invite member (role: admin|editor|viewer)
+  team accept <token>              Accept team invite
+
 List Options:
   --tree           Show dependency tree
   --tools          Show tool usage matrix
@@ -60,9 +76,36 @@ Examples:
   $ claude-skill-sync list         # List all skills
   $ claude-skill-sync list --tree  # Show dependency graph
   $ claude-skill-sync push         # Push local changes
+  $ claude-skill-sync team create "My Team"  # Create a team
+  $ claude-skill-sync team invite abc123 bob@example.com editor
 
 Learn more: https://claudeskill.io
 `);
+};
+
+const promptForMasterKey = async (): Promise<Uint8Array | null> => {
+  const credentials = await loadCredentials();
+  if (!credentials?.salt || !credentials.encryptedMasterKey) {
+    p.log.error("Not logged in. Run 'claude-skill-sync login' first.");
+    return null;
+  }
+
+  const passphrase = await p.password({
+    message: "Enter your passphrase:",
+  });
+
+  if (p.isCancel(passphrase)) {
+    p.log.warning("Cancelled");
+    return null;
+  }
+
+  const masterKey = await getMasterKey(passphrase as string);
+  if (!masterKey) {
+    p.log.error("Invalid passphrase.");
+    return null;
+  }
+
+  return masterKey;
 };
 
 const main = async (): Promise<void> => {
@@ -170,6 +213,77 @@ const main = async (): Promise<void> => {
         p.log.warning("Not configured. Run 'claude-skill-sync' to set up.");
       }
       break;
+
+    case "team": {
+      const subCommand = args[1];
+
+      switch (subCommand) {
+        case "list":
+          await runTeamList();
+          break;
+
+        case "create": {
+          const name = args[2];
+          if (!name) {
+            p.log.error("Usage: claude-skill-sync team create <name>");
+            return;
+          }
+          const masterKey = await promptForMasterKey();
+          if (!masterKey) {
+            return;
+          }
+          await runTeamCreate(name, masterKey);
+          break;
+        }
+
+        case "show": {
+          const teamId = args[2];
+          if (!teamId) {
+            p.log.error("Usage: claude-skill-sync team show <team-id>");
+            return;
+          }
+          await runTeamShow(teamId);
+          break;
+        }
+
+        case "invite": {
+          const teamId = args[2];
+          const email = args[3];
+          const role = args[4] ?? "editor";
+          if (!teamId || !email) {
+            p.log.error("Usage: claude-skill-sync team invite <team-id> <email> [role]");
+            return;
+          }
+          await runTeamInvite(teamId, email, role);
+          break;
+        }
+
+        case "accept": {
+          const token = args[2];
+          if (!token) {
+            p.log.error("Usage: claude-skill-sync team accept <token>");
+            return;
+          }
+          const masterKey = await promptForMasterKey();
+          if (!masterKey) {
+            return;
+          }
+          await runTeamAccept(token, masterKey);
+          break;
+        }
+
+        default:
+          p.log.error(`Unknown team command: ${subCommand}`);
+          console.log("\nTeam Commands:");
+          console.log("  team list                        List your teams");
+          console.log("  team create <name>               Create a new team");
+          console.log("  team show <team-id>              Show team details");
+          console.log("  team invite <team-id> <email> [role]  Invite member");
+          console.log("  team accept <token>              Accept team invite");
+          break;
+      }
+      break;
+    }
 
     default:
       p.log.error(`Unknown command: ${command}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@noble/curves": "^1.8.0",
     "@noble/hashes": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/core/src/crypto.test.ts
+++ b/packages/core/src/crypto.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeKeyFingerprint,
+  decryptTeamKeyAsMember,
+  encryptTeamKeyForMember,
+  generateTeamKey,
+  generateX25519KeyPair,
+} from "./crypto.ts";
+
+test("computeKeyFingerprint is stable for the same key", () => {
+  const keypair = generateX25519KeyPair();
+  const first = computeKeyFingerprint(keypair.publicKey);
+  const second = computeKeyFingerprint(keypair.publicKey);
+
+  assert.equal(first, second);
+  assert.match(first, /^[0-9a-f-]+$/);
+});
+
+test("team key roundtrip succeeds for the intended recipient", () => {
+  const recipient = generateX25519KeyPair();
+  const teamKey = generateTeamKey();
+
+  const envelope = encryptTeamKeyForMember(teamKey, recipient.publicKey);
+  const decrypted = decryptTeamKeyAsMember(
+    envelope.ephemeralPublicKey,
+    envelope.encryptedKey,
+    envelope.iv,
+    envelope.tag,
+    recipient.privateKey
+  );
+
+  assert.deepEqual(decrypted, teamKey);
+});
+
+test("team key decrypt fails for the wrong recipient", () => {
+  const intendedRecipient = generateX25519KeyPair();
+  const wrongRecipient = generateX25519KeyPair();
+  const teamKey = generateTeamKey();
+
+  const envelope = encryptTeamKeyForMember(teamKey, intendedRecipient.publicKey);
+
+  assert.throws(() => {
+    decryptTeamKeyAsMember(
+      envelope.ephemeralPublicKey,
+      envelope.encryptedKey,
+      envelope.iv,
+      envelope.tag,
+      wrongRecipient.privateKey
+    );
+  });
+});
+
+test("tampered team key envelope fails authentication", () => {
+  const recipient = generateX25519KeyPair();
+  const teamKey = generateTeamKey();
+  const envelope = encryptTeamKeyForMember(teamKey, recipient.publicKey);
+  const tamperedCiphertext = Buffer.from(envelope.encryptedKey, "base64");
+  tamperedCiphertext[0] = tamperedCiphertext[0] ^ 0xff;
+
+  assert.throws(() => {
+    decryptTeamKeyAsMember(
+      envelope.ephemeralPublicKey,
+      tamperedCiphertext.toString("base64"),
+      envelope.iv,
+      envelope.tag,
+      recipient.privateKey
+    );
+  });
+});

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -6,9 +6,17 @@
  * 2. Derived key (Argon2id from passphrase + salt)
  * 3. Master key (random 256-bit, encrypted with derived key)
  * 4. Skill data (encrypted with master key)
+ *
+ * Team key hierarchy:
+ * 1. Team master key (random 256-bit, generated when team is created)
+ * 2. Team key is encrypted with each member's public key (X25519 + AES-256-GCM)
+ * 3. Team skill data is encrypted with team master key
  */
 
 import { argon2id } from "@noble/hashes/argon2";
+import { x25519 } from "@noble/curves/ed25519";
+import { hkdf } from "@noble/hashes/hkdf";
+import { sha256 } from "@noble/hashes/sha256";
 import {
   randomBytes,
   createCipheriv,
@@ -288,6 +296,14 @@ export const fromBase64 = (base64: string): Uint8Array => {
 };
 
 /**
+ * Compute a stable, human-readable fingerprint for a public key.
+ */
+export const computeKeyFingerprint = (publicKey: Uint8Array): string => {
+  const digest = createHash("sha256").update(publicKey).digest("hex").slice(0, 32);
+  return digest.match(/.{1,4}/g)?.join("-") ?? digest;
+};
+
+/**
  * Compute SHA-256 hash of content, return short hash (8 chars like git)
  */
 export const computeContentHash = (content: string): string => {
@@ -299,4 +315,154 @@ export const computeContentHash = (content: string): string => {
  */
 export const computeFullHash = (content: string): string => {
   return createHash("sha256").update(content, "utf8").digest("hex");
+};
+
+// =============================================================================
+// X25519 Key Exchange (for team key sharing)
+// =============================================================================
+
+/** X25519 key pair */
+export type X25519KeyPair = {
+  /** Public key (32 bytes) */
+  publicKey: Uint8Array;
+  /** Private key (32 bytes) */
+  privateKey: Uint8Array;
+};
+
+/**
+ * Generate an X25519 key pair for asymmetric encryption
+ * Used for encrypting team keys for individual members
+ */
+export const generateX25519KeyPair = (): X25519KeyPair => {
+  const privateKey = generateRandomBytes(32);
+  const publicKey = x25519.getPublicKey(privateKey);
+  return { publicKey, privateKey };
+};
+
+/**
+ * Derive a shared secret using X25519 ECDH
+ * The shared secret is then used to derive an AES key via HKDF
+ */
+const deriveSharedKey = (
+  privateKey: Uint8Array,
+  publicKey: Uint8Array,
+  context: string = "team-key-exchange"
+): Uint8Array => {
+  // X25519 ECDH to get shared secret
+  const sharedSecret = x25519.getSharedSecret(privateKey, publicKey);
+
+  // Use HKDF to derive a proper AES key from the shared secret
+  const derivedKey = hkdf(sha256, sharedSecret, undefined, context, AES_KEY_LENGTH);
+
+  return derivedKey;
+};
+
+/**
+ * Encrypt data for a specific recipient using their public key
+ * Uses X25519 ECDH + HKDF + AES-256-GCM (ECIES-like construction)
+ *
+ * @param plaintext - Data to encrypt
+ * @param recipientPublicKey - Recipient's X25519 public key
+ * @returns Encrypted data with ephemeral public key, IV, and auth tag
+ */
+export const encryptForRecipient = (
+  plaintext: Uint8Array,
+  recipientPublicKey: Uint8Array
+): {
+  ephemeralPublicKey: Uint8Array;
+  ciphertext: Uint8Array;
+  iv: Uint8Array;
+  tag: Uint8Array;
+} => {
+  // Generate ephemeral keypair for this encryption
+  const ephemeral = generateX25519KeyPair();
+
+  // Derive shared AES key
+  const sharedKey = deriveSharedKey(ephemeral.privateKey, recipientPublicKey);
+
+  // Encrypt with AES-256-GCM
+  const { ciphertext, iv, tag } = encrypt(plaintext, sharedKey);
+
+  return {
+    ephemeralPublicKey: ephemeral.publicKey,
+    ciphertext,
+    iv,
+    tag,
+  };
+};
+
+/**
+ * Decrypt data that was encrypted for us using our private key
+ *
+ * @param ephemeralPublicKey - Sender's ephemeral public key
+ * @param ciphertext - Encrypted data
+ * @param iv - Initialization vector
+ * @param tag - Authentication tag
+ * @param recipientPrivateKey - Our X25519 private key
+ * @returns Decrypted plaintext
+ */
+export const decryptAsRecipient = (
+  ephemeralPublicKey: Uint8Array,
+  ciphertext: Uint8Array,
+  iv: Uint8Array,
+  tag: Uint8Array,
+  recipientPrivateKey: Uint8Array
+): Uint8Array => {
+  // Derive shared AES key (same as sender derived)
+  const sharedKey = deriveSharedKey(recipientPrivateKey, ephemeralPublicKey);
+
+  // Decrypt with AES-256-GCM
+  return decrypt(ciphertext, sharedKey, iv, tag);
+};
+
+/**
+ * Encrypt a team key for a specific member
+ * Returns base64-encoded components for storage/transmission
+ */
+export const encryptTeamKeyForMember = (
+  teamKey: Uint8Array,
+  memberPublicKey: Uint8Array
+): {
+  ephemeralPublicKey: string;
+  encryptedKey: string;
+  iv: string;
+  tag: string;
+} => {
+  const { ephemeralPublicKey, ciphertext, iv, tag } = encryptForRecipient(
+    teamKey,
+    memberPublicKey
+  );
+
+  return {
+    ephemeralPublicKey: toBase64(ephemeralPublicKey),
+    encryptedKey: toBase64(ciphertext),
+    iv: toBase64(iv),
+    tag: toBase64(tag),
+  };
+};
+
+/**
+ * Decrypt a team key that was encrypted for us
+ */
+export const decryptTeamKeyAsMember = (
+  ephemeralPublicKey: string,
+  encryptedKey: string,
+  iv: string,
+  tag: string,
+  memberPrivateKey: Uint8Array
+): Uint8Array => {
+  return decryptAsRecipient(
+    fromBase64(ephemeralPublicKey),
+    fromBase64(encryptedKey),
+    fromBase64(iv),
+    fromBase64(tag),
+    memberPrivateKey
+  );
+};
+
+/**
+ * Generate a new team master key
+ */
+export const generateTeamKey = (): Uint8Array => {
+  return generateRandomBytes(AES_KEY_LENGTH);
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,36 +10,54 @@ export type {
   Credentials,
   DerivedKey,
   EncryptedBlob,
+  EncryptedTeamKey,
   RecoveryKey,
   Skill,
   SkillMetadata,
   SkillType,
   SyncedSkill,
   SyncStatus,
+  Team,
+  TeamCredentials,
+  TeamInvite,
+  TeamMember,
+  TeamMemberStatus,
+  TeamRole,
+  TeamWithMembership,
   Vault,
 } from "./types.js";
 
 // Crypto operations
 export {
   computeContentHash,
+  computeKeyFingerprint,
   computeFullHash,
   decrypt,
+  decryptAsRecipient,
   decryptMasterKey,
   decryptString,
+  decryptTeamKeyAsMember,
   deriveKeyFromPassphrase,
   deriveKeyFromRecoveryKey,
   encrypt,
+  encryptForRecipient,
   encryptMasterKey,
   encryptString,
+  encryptTeamKeyForMember,
   formatRecoveryKey,
   fromBase64,
   generateMasterKey,
   generateRandomBytes,
   generateRecoveryKey,
   generateSalt,
+  generateTeamKey,
+  generateX25519KeyPair,
   parseRecoveryKey,
   toBase64,
 } from "./crypto.js";
+
+// Re-export X25519 types
+export type { X25519KeyPair } from "./crypto.js";
 
 // Skill operations
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,4 +137,118 @@ export type Credentials = {
   encryptedMasterKey: string;
   /** Salt for key derivation (base64) */
   salt: string;
+  /** User's X25519 public key (base64) - for team key exchange */
+  publicKey?: string;
+  /** User's X25519 private key encrypted with master key (base64) */
+  encryptedPrivateKey?: string;
+  /** IV for encrypted private key */
+  privateKeyIv?: string;
+  /** Auth tag for encrypted private key */
+  privateKeyTag?: string;
+  /** Stable fingerprint for the user's current X25519 public key */
+  publicKeyFingerprint?: string;
+  /** Trust-on-first-use cache for other members' public key fingerprints */
+  knownPublicKeyFingerprints?: Record<string, string>;
+};
+
+// =============================================================================
+// Team Types
+// =============================================================================
+
+/** Team role levels */
+export type TeamRole = "owner" | "admin" | "editor" | "viewer";
+
+/** Team member status */
+export type TeamMemberStatus = "pending" | "active";
+
+/** Team information */
+export type Team = {
+  /** Team ID */
+  id: string;
+  /** Team name */
+  name: string;
+  /** Team owner user ID */
+  ownerId: string;
+  /** Created timestamp */
+  createdAt: string;
+};
+
+/** Team member information */
+export type TeamMember = {
+  /** Team ID */
+  teamId: string;
+  /** User ID */
+  userId: string;
+  /** User email */
+  email: string;
+  /** Member role */
+  role: TeamRole;
+  /** Member status */
+  status: TeamMemberStatus;
+  /** Whether this member has received the team key */
+  hasTeamKey: boolean;
+  /** Stable fingerprint for this member's public key, when available */
+  publicKeyFingerprint?: string | null;
+  /** Joined timestamp */
+  createdAt: string;
+};
+
+/** Team invite information */
+export type TeamInvite = {
+  /** Invite ID */
+  id: string;
+  /** Team ID */
+  teamId: string;
+  /** Team name */
+  teamName: string;
+  /** Invited email */
+  email: string;
+  /** Role to be assigned */
+  role: TeamRole;
+  /** Expiration timestamp */
+  expiresAt: string;
+  /** Created by user ID */
+  createdBy: string;
+  /** Created timestamp */
+  createdAt: string;
+};
+
+/** Team with membership info for current user */
+export type TeamWithMembership = Team & {
+  /** Current user's role in the team */
+  role: TeamRole;
+  /** Current user's status */
+  status: TeamMemberStatus;
+  /** Number of members */
+  memberCount: number;
+  /** Number of skills */
+  skillCount: number;
+};
+
+/** Encrypted team key for a member */
+export type EncryptedTeamKey = {
+  /** Team ID */
+  teamId: string;
+  /** Team key version this envelope belongs to */
+  teamKeyVersion: number;
+  /** Encrypted team key (encrypted with member's public key) */
+  encryptedKey: string;
+  /** IV for encryption */
+  iv: string;
+  /** Auth tag */
+  tag: string;
+  /** Sender ephemeral public key */
+  ephemeralPublicKey: string;
+};
+
+/** Local team credentials (stored in credentials file) */
+export type TeamCredentials = {
+  /** Team ID */
+  teamId: string;
+  /** Decrypted team master key (base64) - stored encrypted with user's master key */
+  encryptedTeamKey: string;
+  /** IV for team key encryption */
+  teamKeyIv: string;
+  /** Auth tag for team key encryption */
+  teamKeyTag: string;
 };

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -3,9 +3,6 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Install build dependencies for better-sqlite3
-RUN apk add --no-cache python3 make g++
-
 # Copy package files
 COPY package.json yarn.lock ./
 COPY packages/core/package.json ./packages/core/
@@ -28,9 +25,6 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install runtime dependencies for better-sqlite3
-RUN apk add --no-cache python3 make g++
-
 # Copy package files
 COPY package.json yarn.lock ./
 COPY packages/core/package.json ./packages/core/
@@ -43,13 +37,10 @@ RUN yarn install --frozen-lockfile --production
 COPY --from=builder /app/packages/core/dist ./packages/core/dist
 COPY --from=builder /app/packages/server/dist ./packages/server/dist
 
-# Create data directory
-RUN mkdir -p /app/data
-
 # Environment
 ENV NODE_ENV=production
 ENV PORT=3001
-ENV DATABASE_PATH=/app/data/skills.db
+ENV ENABLE_TEAM_SHARING=false
 
 EXPOSE 3001
 

--- a/packages/server/drizzle/0000_petite_maggott.sql
+++ b/packages/server/drizzle/0000_petite_maggott.sql
@@ -1,0 +1,167 @@
+CREATE TABLE "blobs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"encrypted_data" text NOT NULL,
+	"iv" text NOT NULL,
+	"tag" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "otp_codes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"code" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"used" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"refresh_token_hash" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "skill_versions" (
+	"hash" text NOT NULL,
+	"skill_id" uuid NOT NULL,
+	"encrypted_data" text NOT NULL,
+	"iv" text NOT NULL,
+	"tag" text NOT NULL,
+	"parent_hash" text,
+	"message" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "skill_versions_skill_id_hash_pk" PRIMARY KEY("skill_id","hash")
+);
+--> statement-breakpoint
+CREATE TABLE "skills" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"skill_key" text NOT NULL,
+	"current_hash" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "team_invites" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"team_id" uuid NOT NULL,
+	"email" text NOT NULL,
+	"role" text NOT NULL,
+	"token_hash" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"used_at" timestamp,
+	"created_by" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "team_key_envelopes" (
+	"team_id" uuid NOT NULL,
+	"team_key_version" integer NOT NULL,
+	"recipient_user_id" uuid NOT NULL,
+	"wrapped_by_user_id" uuid NOT NULL,
+	"encrypted_team_key" text NOT NULL,
+	"iv" text NOT NULL,
+	"tag" text NOT NULL,
+	"ephemeral_public_key" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "team_key_envelopes_team_id_team_key_version_recipient_user_id_pk" PRIMARY KEY("team_id","team_key_version","recipient_user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "team_members" (
+	"team_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"encrypted_team_key" text,
+	"team_key_iv" text,
+	"team_key_tag" text,
+	"ephemeral_public_key" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "team_members_team_id_user_id_pk" PRIMARY KEY("team_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "team_skill_versions" (
+	"hash" text NOT NULL,
+	"skill_id" uuid NOT NULL,
+	"encrypted_data" text NOT NULL,
+	"iv" text NOT NULL,
+	"tag" text NOT NULL,
+	"team_key_version" integer DEFAULT 1 NOT NULL,
+	"parent_hash" text,
+	"message" text,
+	"created_by" uuid,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "team_skill_versions_skill_id_hash_pk" PRIMARY KEY("skill_id","hash")
+);
+--> statement-breakpoint
+CREATE TABLE "team_skills" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"team_id" uuid NOT NULL,
+	"skill_key" text NOT NULL,
+	"current_hash" text,
+	"created_by" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "teams" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"active_key_version" integer DEFAULT 1 NOT NULL,
+	"owner_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"salt" text,
+	"encrypted_master_key" text,
+	"recovery_blob" text,
+	"public_key" text,
+	"public_key_fingerprint" text,
+	"encrypted_private_key" text,
+	"private_key_iv" text,
+	"private_key_tag" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+ALTER TABLE "blobs" ADD CONSTRAINT "blobs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "skill_versions" ADD CONSTRAINT "skill_versions_skill_id_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "skills" ADD CONSTRAINT "skills_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_invites" ADD CONSTRAINT "team_invites_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_invites" ADD CONSTRAINT "team_invites_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_key_envelopes" ADD CONSTRAINT "team_key_envelopes_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_key_envelopes" ADD CONSTRAINT "team_key_envelopes_recipient_user_id_users_id_fk" FOREIGN KEY ("recipient_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_key_envelopes" ADD CONSTRAINT "team_key_envelopes_wrapped_by_user_id_users_id_fk" FOREIGN KEY ("wrapped_by_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_skill_versions" ADD CONSTRAINT "team_skill_versions_skill_id_team_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."team_skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_skill_versions" ADD CONSTRAINT "team_skill_versions_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_skills" ADD CONSTRAINT "team_skills_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_skills" ADD CONSTRAINT "team_skills_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "teams" ADD CONSTRAINT "teams_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_blobs_user_id" ON "blobs" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_otp_codes_email" ON "otp_codes" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "idx_sessions_user_id" ON "sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_skill_versions_skill_id" ON "skill_versions" USING btree ("skill_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_skills_user_skill" ON "skills" USING btree ("user_id","skill_key");--> statement-breakpoint
+CREATE INDEX "idx_skills_user_id" ON "skills" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_team_invites_team_id" ON "team_invites" USING btree ("team_id");--> statement-breakpoint
+CREATE INDEX "idx_team_invites_email" ON "team_invites" USING btree ("email");--> statement-breakpoint
+CREATE INDEX "idx_team_invites_token_hash" ON "team_invites" USING btree ("token_hash");--> statement-breakpoint
+CREATE INDEX "idx_team_key_envelopes_recipient" ON "team_key_envelopes" USING btree ("recipient_user_id");--> statement-breakpoint
+CREATE INDEX "idx_team_key_envelopes_team_version" ON "team_key_envelopes" USING btree ("team_id","team_key_version");--> statement-breakpoint
+CREATE INDEX "idx_team_members_user_id" ON "team_members" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_team_skill_versions_skill_id" ON "team_skill_versions" USING btree ("skill_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_team_skills_team_skill" ON "team_skills" USING btree ("team_id","skill_key");--> statement-breakpoint
+CREATE INDEX "idx_team_skills_team_id" ON "team_skills" USING btree ("team_id");

--- a/packages/server/drizzle/meta/0000_snapshot.json
+++ b/packages/server/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1287 @@
+{
+  "id": "01742f9f-dd46-4402-9f67-23b39eaa2bee",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_data": {
+          "name": "encrypted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_user_id": {
+          "name": "idx_blobs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blobs_user_id_users_id_fk": {
+          "name": "blobs_user_id_users_id_fk",
+          "tableFrom": "blobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_codes": {
+      "name": "otp_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_otp_codes_email": {
+          "name": "idx_otp_codes_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_versions": {
+      "name": "skill_versions",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_data": {
+          "name": "encrypted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_hash": {
+          "name": "parent_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_versions_skill_id": {
+          "name": "idx_skill_versions_skill_id",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_versions_skill_id_skills_id_fk": {
+          "name": "skill_versions_skill_id_skills_id_fk",
+          "tableFrom": "skill_versions",
+          "tableTo": "skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "skill_versions_skill_id_hash_pk": {
+          "name": "skill_versions_skill_id_hash_pk",
+          "columns": [
+            "skill_id",
+            "hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_key": {
+          "name": "skill_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_hash": {
+          "name": "current_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_user_skill": {
+          "name": "idx_skills_user_skill",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_user_id": {
+          "name": "idx_skills_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_user_id_users_id_fk": {
+          "name": "skills_user_id_users_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invites": {
+      "name": "team_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_team_invites_team_id": {
+          "name": "idx_team_invites_team_id",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_invites_email": {
+          "name": "idx_team_invites_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_invites_token_hash": {
+          "name": "idx_team_invites_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invites_team_id_teams_id_fk": {
+          "name": "team_invites_team_id_teams_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invites_created_by_users_id_fk": {
+          "name": "team_invites_created_by_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_key_envelopes": {
+      "name": "team_key_envelopes",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_key_version": {
+          "name": "team_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_user_id": {
+          "name": "wrapped_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_team_key": {
+          "name": "encrypted_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ephemeral_public_key": {
+          "name": "ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_team_key_envelopes_recipient": {
+          "name": "idx_team_key_envelopes_recipient",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_key_envelopes_team_version": {
+          "name": "idx_team_key_envelopes_team_version",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_key_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_key_envelopes_team_id_teams_id_fk": {
+          "name": "team_key_envelopes_team_id_teams_id_fk",
+          "tableFrom": "team_key_envelopes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_key_envelopes_recipient_user_id_users_id_fk": {
+          "name": "team_key_envelopes_recipient_user_id_users_id_fk",
+          "tableFrom": "team_key_envelopes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_key_envelopes_wrapped_by_user_id_users_id_fk": {
+          "name": "team_key_envelopes_wrapped_by_user_id_users_id_fk",
+          "tableFrom": "team_key_envelopes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "wrapped_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_key_envelopes_team_id_team_key_version_recipient_user_id_pk": {
+          "name": "team_key_envelopes_team_id_team_key_version_recipient_user_id_pk",
+          "columns": [
+            "team_id",
+            "team_key_version",
+            "recipient_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "encrypted_team_key": {
+          "name": "encrypted_team_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_key_iv": {
+          "name": "team_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_key_tag": {
+          "name": "team_key_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ephemeral_public_key": {
+          "name": "ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_team_members_user_id": {
+          "name": "idx_team_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_user_id_pk": {
+          "name": "team_members_team_id_user_id_pk",
+          "columns": [
+            "team_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_skill_versions": {
+      "name": "team_skill_versions",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_data": {
+          "name": "encrypted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_key_version": {
+          "name": "team_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_hash": {
+          "name": "parent_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_team_skill_versions_skill_id": {
+          "name": "idx_team_skill_versions_skill_id",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_skill_versions_skill_id_team_skills_id_fk": {
+          "name": "team_skill_versions_skill_id_team_skills_id_fk",
+          "tableFrom": "team_skill_versions",
+          "tableTo": "team_skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_skill_versions_created_by_users_id_fk": {
+          "name": "team_skill_versions_created_by_users_id_fk",
+          "tableFrom": "team_skill_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_skill_versions_skill_id_hash_pk": {
+          "name": "team_skill_versions_skill_id_hash_pk",
+          "columns": [
+            "skill_id",
+            "hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_skills": {
+      "name": "team_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_key": {
+          "name": "skill_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_hash": {
+          "name": "current_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_team_skills_team_skill": {
+          "name": "idx_team_skills_team_skill",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_skills_team_id": {
+          "name": "idx_team_skills_team_id",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_skills_team_id_teams_id_fk": {
+          "name": "team_skills_team_id_teams_id_fk",
+          "tableFrom": "team_skills",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_skills_created_by_users_id_fk": {
+          "name": "team_skills_created_by_users_id_fk",
+          "tableFrom": "team_skills",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_key_version": {
+          "name": "active_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_owner_id_users_id_fk": {
+          "name": "teams_owner_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt": {
+          "name": "salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_master_key": {
+          "name": "encrypted_master_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_blob": {
+          "name": "recovery_blob",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key_fingerprint": {
+          "name": "public_key_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_private_key": {
+          "name": "encrypted_private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key_iv": {
+          "name": "private_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key_tag": {
+          "name": "private_key_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773216934455,
+      "tag": "0000_petite_maggott",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/server/drizzle/prod/20260311_team_share_incremental.sql
+++ b/packages/server/drizzle/prod/20260311_team_share_incremental.sql
@@ -1,0 +1,58 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS public_key text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS public_key_fingerprint text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS encrypted_private_key text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS private_key_iv text;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS private_key_tag text;
+
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS active_key_version integer NOT NULL DEFAULT 1;
+
+ALTER TABLE team_skill_versions ADD COLUMN IF NOT EXISTS team_key_version integer NOT NULL DEFAULT 1;
+
+CREATE TABLE IF NOT EXISTS team_key_envelopes (
+  team_id uuid NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  team_key_version integer NOT NULL,
+  recipient_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  wrapped_by_user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  encrypted_team_key text NOT NULL,
+  iv text NOT NULL,
+  tag text NOT NULL,
+  ephemeral_public_key text NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  PRIMARY KEY (team_id, team_key_version, recipient_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_key_envelopes_recipient
+  ON team_key_envelopes (recipient_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_team_key_envelopes_team_version
+  ON team_key_envelopes (team_id, team_key_version);
+
+INSERT INTO team_key_envelopes (
+  team_id,
+  team_key_version,
+  recipient_user_id,
+  wrapped_by_user_id,
+  encrypted_team_key,
+  iv,
+  tag,
+  ephemeral_public_key,
+  created_at
+)
+SELECT
+  tm.team_id,
+  COALESCE(t.active_key_version, 1),
+  tm.user_id,
+  t.owner_id,
+  tm.encrypted_team_key,
+  tm.team_key_iv,
+  tm.team_key_tag,
+  tm.ephemeral_public_key,
+  tm.updated_at
+FROM team_members tm
+JOIN teams t ON t.id = tm.team_id
+WHERE
+  tm.encrypted_team_key IS NOT NULL
+  AND tm.team_key_iv IS NOT NULL
+  AND tm.team_key_tag IS NOT NULL
+  AND tm.ephemeral_public_key IS NOT NULL
+ON CONFLICT (team_id, team_key_version, recipient_user_id) DO NOTHING;

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -5,6 +5,7 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import { eq, and, gt, lt, desc, sql, count } from "drizzle-orm";
 import postgres from "postgres";
+import { createHash } from "node:crypto";
 import {
   users,
   otpCodes,
@@ -12,12 +13,24 @@ import {
   blobs,
   skills,
   skillVersions,
+  teams,
+  teamMembers,
+  teamKeyEnvelopes,
+  teamInvites,
+  teamSkills,
+  teamSkillVersions,
   type User,
   type OtpCode,
   type Session,
   type Blob,
   type Skill,
   type SkillVersion,
+  type Team,
+  type TeamMember,
+  type TeamKeyEnvelope,
+  type TeamInvite,
+  type TeamSkill,
+  type TeamSkillVersion,
 } from "./schema.js";
 
 // Re-export types with legacy names for backward compatibility
@@ -27,6 +40,12 @@ export type SessionRecord = Session;
 export type BlobRecord = Blob;
 export type SkillRecord = Skill;
 export type SkillVersionRecord = SkillVersion;
+export type TeamRecord = Team;
+export type TeamMemberRecord = TeamMember;
+export type TeamKeyEnvelopeRecord = TeamKeyEnvelope;
+export type TeamInviteRecord = TeamInvite;
+export type TeamSkillRecord = TeamSkill;
+export type TeamSkillVersionRecord = TeamSkillVersion;
 
 // =============================================================================
 // Database Connection
@@ -39,6 +58,14 @@ if (!connectionString) {
 
 const client = postgres(connectionString);
 const db = drizzle(client);
+
+const computePublicKeyFingerprint = (publicKey: string): string => {
+  const digest = createHash("sha256")
+    .update(Buffer.from(publicKey, "base64"))
+    .digest("hex")
+    .slice(0, 32);
+  return digest.match(/.{1,4}/g)?.join("-") ?? digest;
+};
 
 /**
  * Get database instance (for compatibility)
@@ -426,4 +453,787 @@ export const countSkillVersions = async (skillId: string): Promise<number> => {
     .from(skillVersions)
     .where(eq(skillVersions.skillId, skillId));
   return result[0]?.count ?? 0;
+};
+
+// =============================================================================
+// User keypair queries
+// =============================================================================
+
+export const updateUserPublicKey = async (
+  userId: string,
+  publicKey: string,
+  encryptedPrivateKey: string,
+  privateKeyIv: string,
+  privateKeyTag: string
+): Promise<void> => {
+  const publicKeyFingerprint = computePublicKeyFingerprint(publicKey);
+
+  await db
+    .update(users)
+    .set({
+      publicKey,
+      publicKeyFingerprint,
+      encryptedPrivateKey,
+      privateKeyIv,
+      privateKeyTag,
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, userId));
+};
+
+export const getUserPublicKey = async (
+  userId: string
+): Promise<{ publicKey: string; publicKeyFingerprint: string | null } | undefined> => {
+  const result = await db
+    .select({
+      publicKey: users.publicKey,
+      publicKeyFingerprint: users.publicKeyFingerprint,
+    })
+    .from(users)
+    .where(eq(users.id, userId));
+  if (!result[0]?.publicKey) return undefined;
+  return {
+    publicKey: result[0].publicKey,
+    publicKeyFingerprint: result[0].publicKeyFingerprint,
+  };
+};
+
+export const getUserKeyPair = async (
+  userId: string
+): Promise<{
+  publicKey: string;
+  publicKeyFingerprint: string | null;
+  encryptedPrivateKey: string;
+  privateKeyIv: string;
+  privateKeyTag: string;
+} | null> => {
+  const result = await db
+    .select({
+      publicKey: users.publicKey,
+      publicKeyFingerprint: users.publicKeyFingerprint,
+      encryptedPrivateKey: users.encryptedPrivateKey,
+      privateKeyIv: users.privateKeyIv,
+      privateKeyTag: users.privateKeyTag,
+    })
+    .from(users)
+    .where(eq(users.id, userId));
+
+  const row = result[0];
+  if (
+    !row?.publicKey ||
+    !row?.encryptedPrivateKey ||
+    !row?.privateKeyIv ||
+    !row?.privateKeyTag
+  ) {
+    return null;
+  }
+
+  return {
+    publicKey: row.publicKey,
+    publicKeyFingerprint: row.publicKeyFingerprint,
+    encryptedPrivateKey: row.encryptedPrivateKey,
+    privateKeyIv: row.privateKeyIv,
+    privateKeyTag: row.privateKeyTag,
+  };
+};
+
+// =============================================================================
+// Team queries
+// =============================================================================
+
+export const createTeam = async (
+  name: string,
+  ownerId: string
+): Promise<Team> => {
+  const result = await db
+    .insert(teams)
+    .values({ name, ownerId })
+    .returning();
+  return result[0]!;
+};
+
+export const findTeamById = async (id: string): Promise<Team | undefined> => {
+  const result = await db.select().from(teams).where(eq(teams.id, id));
+  return result[0];
+};
+
+export const updateTeamName = async (
+  teamId: string,
+  name: string
+): Promise<void> => {
+  await db
+    .update(teams)
+    .set({ name, updatedAt: new Date() })
+    .where(eq(teams.id, teamId));
+};
+
+export const deleteTeam = async (teamId: string): Promise<boolean> => {
+  const result = await db
+    .delete(teams)
+    .where(eq(teams.id, teamId))
+    .returning({ id: teams.id });
+  return result.length > 0;
+};
+
+export type TeamWithMemberInfo = Team & {
+  role: string;
+  status: string;
+  memberCount: number;
+  skillCount: number;
+  activeKeyVersion: number;
+};
+
+export const listUserTeams = async (
+  userId: string
+): Promise<TeamWithMemberInfo[]> => {
+  // Get teams the user is a member of
+  const memberTeams = await db
+    .select({
+      id: teams.id,
+      name: teams.name,
+      activeKeyVersion: teams.activeKeyVersion,
+      ownerId: teams.ownerId,
+      createdAt: teams.createdAt,
+      updatedAt: teams.updatedAt,
+      role: teamMembers.role,
+      status: teamMembers.status,
+    })
+    .from(teamMembers)
+    .innerJoin(teams, eq(teamMembers.teamId, teams.id))
+    .where(eq(teamMembers.userId, userId));
+
+  // Get member counts and skill counts for each team
+  const result: TeamWithMemberInfo[] = [];
+  for (const team of memberTeams) {
+    const [memberCountResult, skillCountResult] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(teamMembers)
+        .where(eq(teamMembers.teamId, team.id)),
+      db
+        .select({ count: count() })
+        .from(teamSkills)
+        .where(eq(teamSkills.teamId, team.id)),
+    ]);
+
+    result.push({
+      ...team,
+      memberCount: memberCountResult[0]?.count ?? 0,
+      skillCount: skillCountResult[0]?.count ?? 0,
+    });
+  }
+
+  return result;
+};
+
+// =============================================================================
+// Team member queries
+// =============================================================================
+
+export const addTeamMember = async (
+  teamId: string,
+  userId: string,
+  role: string,
+  status: string = "pending"
+): Promise<TeamMember> => {
+  const result = await db
+    .insert(teamMembers)
+    .values({ teamId, userId, role, status })
+    .returning();
+  return result[0]!;
+};
+
+export const findTeamMember = async (
+  teamId: string,
+  userId: string
+): Promise<TeamMember | undefined> => {
+  const result = await db
+    .select()
+    .from(teamMembers)
+    .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)));
+  return result[0];
+};
+
+export const updateTeamMemberStatus = async (
+  teamId: string,
+  userId: string,
+  status: string
+): Promise<void> => {
+  await db
+    .update(teamMembers)
+    .set({ status, updatedAt: new Date() })
+    .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)));
+};
+
+export const updateTeamMemberRole = async (
+  teamId: string,
+  userId: string,
+  role: string
+): Promise<void> => {
+  await db
+    .update(teamMembers)
+    .set({ role, updatedAt: new Date() })
+    .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)));
+};
+
+export const setTeamMemberKey = async (
+  teamId: string,
+  userId: string,
+  encryptedTeamKey: string,
+  teamKeyIv: string,
+  teamKeyTag: string,
+  ephemeralPublicKey: string,
+  teamKeyVersion: number,
+  wrappedByUserId: string
+): Promise<void> => {
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(teamKeyEnvelopes)
+      .values({
+        teamId,
+        teamKeyVersion,
+        recipientUserId: userId,
+        wrappedByUserId,
+        encryptedTeamKey,
+        iv: teamKeyIv,
+        tag: teamKeyTag,
+        ephemeralPublicKey,
+      })
+      .onConflictDoUpdate({
+        target: [
+          teamKeyEnvelopes.teamId,
+          teamKeyEnvelopes.teamKeyVersion,
+          teamKeyEnvelopes.recipientUserId,
+        ],
+        set: {
+          wrappedByUserId,
+          encryptedTeamKey,
+          iv: teamKeyIv,
+          tag: teamKeyTag,
+          ephemeralPublicKey,
+          createdAt: new Date(),
+        },
+      });
+
+    await tx
+      .update(teamMembers)
+      .set({
+        encryptedTeamKey,
+        teamKeyIv,
+        teamKeyTag,
+        ephemeralPublicKey,
+        status: "active",
+        updatedAt: new Date(),
+      })
+      .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)));
+  });
+};
+
+export const removeTeamMember = async (
+  teamId: string,
+  userId: string
+): Promise<boolean> => {
+  const result = await db
+    .delete(teamMembers)
+    .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)))
+    .returning({ teamId: teamMembers.teamId });
+  return result.length > 0;
+};
+
+export const getTeamActiveKeyVersion = async (
+  teamId: string
+): Promise<number | null> => {
+  const result = await db
+    .select({ activeKeyVersion: teams.activeKeyVersion })
+    .from(teams)
+    .where(eq(teams.id, teamId));
+  return result[0]?.activeKeyVersion ?? null;
+};
+
+export type TeamEnvelopeInput = {
+  recipientUserId: string;
+  encryptedTeamKey: string;
+  iv: string;
+  tag: string;
+  ephemeralPublicKey: string;
+};
+
+export const rotateTeamKeyAndRemoveMember = async (
+  teamId: string,
+  removedUserId: string,
+  nextTeamKeyVersion: number,
+  wrappedByUserId: string,
+  envelopes: TeamEnvelopeInput[]
+): Promise<void> => {
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(teamMembers)
+      .where(
+        and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, removedUserId))
+      );
+
+    await tx
+      .update(teams)
+      .set({ activeKeyVersion: nextTeamKeyVersion, updatedAt: new Date() })
+      .where(eq(teams.id, teamId));
+
+    for (const envelope of envelopes) {
+      await tx
+        .insert(teamKeyEnvelopes)
+        .values({
+          teamId,
+          teamKeyVersion: nextTeamKeyVersion,
+          recipientUserId: envelope.recipientUserId,
+          wrappedByUserId,
+          encryptedTeamKey: envelope.encryptedTeamKey,
+          iv: envelope.iv,
+          tag: envelope.tag,
+          ephemeralPublicKey: envelope.ephemeralPublicKey,
+        })
+        .onConflictDoUpdate({
+          target: [
+            teamKeyEnvelopes.teamId,
+            teamKeyEnvelopes.teamKeyVersion,
+            teamKeyEnvelopes.recipientUserId,
+          ],
+          set: {
+            wrappedByUserId,
+            encryptedTeamKey: envelope.encryptedTeamKey,
+            iv: envelope.iv,
+            tag: envelope.tag,
+            ephemeralPublicKey: envelope.ephemeralPublicKey,
+            createdAt: new Date(),
+          },
+        });
+
+      await tx
+        .update(teamMembers)
+        .set({
+          encryptedTeamKey: envelope.encryptedTeamKey,
+          teamKeyIv: envelope.iv,
+          teamKeyTag: envelope.tag,
+          ephemeralPublicKey: envelope.ephemeralPublicKey,
+          status: "active",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(teamMembers.teamId, teamId),
+            eq(teamMembers.userId, envelope.recipientUserId)
+          )
+        );
+    }
+  });
+};
+
+export type TeamMemberWithEmail = TeamMember & { email: string };
+
+export const listTeamMembers = async (
+  teamId: string
+): Promise<TeamMemberWithEmail[]> => {
+  const result = await db
+    .select({
+      teamId: teamMembers.teamId,
+      userId: teamMembers.userId,
+      role: teamMembers.role,
+      status: teamMembers.status,
+      encryptedTeamKey: teamMembers.encryptedTeamKey,
+      teamKeyIv: teamMembers.teamKeyIv,
+      teamKeyTag: teamMembers.teamKeyTag,
+      ephemeralPublicKey: teamMembers.ephemeralPublicKey,
+      createdAt: teamMembers.createdAt,
+      updatedAt: teamMembers.updatedAt,
+      email: users.email,
+    })
+    .from(teamMembers)
+    .innerJoin(users, eq(teamMembers.userId, users.id))
+    .where(eq(teamMembers.teamId, teamId));
+  return result;
+};
+
+export const getActiveTeamKeyEnvelopeForMember = async (
+  teamId: string,
+  userId: string
+): Promise<
+  | {
+      encryptedTeamKey: string;
+      iv: string;
+      tag: string;
+      ephemeralPublicKey: string;
+      teamKeyVersion: number;
+    }
+  | null
+> => {
+  const activeKeyVersion = await getTeamActiveKeyVersion(teamId);
+  if (!activeKeyVersion) {
+    return null;
+  }
+
+  const result = await db
+    .select({
+      encryptedTeamKey: teamKeyEnvelopes.encryptedTeamKey,
+      iv: teamKeyEnvelopes.iv,
+      tag: teamKeyEnvelopes.tag,
+      ephemeralPublicKey: teamKeyEnvelopes.ephemeralPublicKey,
+      teamKeyVersion: teamKeyEnvelopes.teamKeyVersion,
+    })
+    .from(teamKeyEnvelopes)
+    .where(
+      and(
+        eq(teamKeyEnvelopes.teamId, teamId),
+        eq(teamKeyEnvelopes.teamKeyVersion, activeKeyVersion),
+        eq(teamKeyEnvelopes.recipientUserId, userId)
+      )
+    );
+
+  return result[0] ?? null;
+};
+
+export const listPendingTeamMembers = async (
+  teamId: string
+): Promise<TeamMemberWithEmail[]> => {
+  const result = await db
+    .select({
+      teamId: teamMembers.teamId,
+      userId: teamMembers.userId,
+      role: teamMembers.role,
+      status: teamMembers.status,
+      encryptedTeamKey: teamMembers.encryptedTeamKey,
+      teamKeyIv: teamMembers.teamKeyIv,
+      teamKeyTag: teamMembers.teamKeyTag,
+      ephemeralPublicKey: teamMembers.ephemeralPublicKey,
+      createdAt: teamMembers.createdAt,
+      updatedAt: teamMembers.updatedAt,
+      email: users.email,
+    })
+    .from(teamMembers)
+    .innerJoin(users, eq(teamMembers.userId, users.id))
+    .where(
+      and(eq(teamMembers.teamId, teamId), eq(teamMembers.status, "pending"))
+    );
+  return result;
+};
+
+// Get pending members across all teams where user is owner/admin
+export const listAllPendingMembersForUser = async (
+  userId: string
+): Promise<
+  (TeamMemberWithEmail & {
+    teamName: string;
+    memberPublicKey: string | null;
+    memberPublicKeyFingerprint: string | null;
+  })[]
+> => {
+  // First get teams where user is an active owner.
+  const userTeams = await db
+    .select({ teamId: teamMembers.teamId })
+    .from(teamMembers)
+    .where(
+      and(
+        eq(teamMembers.userId, userId),
+        eq(teamMembers.status, "active"),
+        eq(teamMembers.role, "owner")
+      )
+    );
+
+  const result: (TeamMemberWithEmail & {
+    teamName: string;
+    memberPublicKey: string | null;
+    memberPublicKeyFingerprint: string | null;
+  })[] = [];
+
+  for (const { teamId } of userTeams) {
+    // Check if user still has permission (owner only).
+    const membership = await findTeamMember(teamId, userId);
+    if (!membership || membership.role !== "owner") {
+      continue;
+    }
+
+    const team = await findTeamById(teamId);
+    if (!team) continue;
+
+    const pendingMembers = await db
+      .select({
+        teamId: teamMembers.teamId,
+        userId: teamMembers.userId,
+        role: teamMembers.role,
+        status: teamMembers.status,
+        encryptedTeamKey: teamMembers.encryptedTeamKey,
+        teamKeyIv: teamMembers.teamKeyIv,
+        teamKeyTag: teamMembers.teamKeyTag,
+        ephemeralPublicKey: teamMembers.ephemeralPublicKey,
+        createdAt: teamMembers.createdAt,
+        updatedAt: teamMembers.updatedAt,
+        email: users.email,
+        memberPublicKey: users.publicKey,
+        memberPublicKeyFingerprint: users.publicKeyFingerprint,
+      })
+      .from(teamMembers)
+      .innerJoin(users, eq(teamMembers.userId, users.id))
+      .where(
+        and(eq(teamMembers.teamId, teamId), eq(teamMembers.status, "pending"))
+      );
+
+    for (const member of pendingMembers) {
+      result.push({
+        ...member,
+        teamName: team.name,
+      });
+    }
+  }
+
+  return result;
+};
+
+// =============================================================================
+// Team invite queries
+// =============================================================================
+
+export const createTeamInvite = async (
+  teamId: string,
+  email: string,
+  role: string,
+  tokenHash: string,
+  createdBy: string,
+  expiresInHours: number = 72
+): Promise<TeamInvite> => {
+  const expiresAt = new Date(Date.now() + expiresInHours * 60 * 60 * 1000);
+  const result = await db
+    .insert(teamInvites)
+    .values({ teamId, email, role, tokenHash, createdBy, expiresAt })
+    .returning();
+  return result[0]!;
+};
+
+export const findTeamInviteByTokenHash = async (
+  tokenHash: string
+): Promise<(TeamInvite & { teamName: string }) | undefined> => {
+  const result = await db
+    .select({
+      id: teamInvites.id,
+      teamId: teamInvites.teamId,
+      email: teamInvites.email,
+      role: teamInvites.role,
+      tokenHash: teamInvites.tokenHash,
+      expiresAt: teamInvites.expiresAt,
+      usedAt: teamInvites.usedAt,
+      createdBy: teamInvites.createdBy,
+      createdAt: teamInvites.createdAt,
+      teamName: teams.name,
+    })
+    .from(teamInvites)
+    .innerJoin(teams, eq(teamInvites.teamId, teams.id))
+    .where(eq(teamInvites.tokenHash, tokenHash));
+  return result[0];
+};
+
+export const findValidTeamInvite = async (
+  tokenHash: string
+): Promise<(TeamInvite & { teamName: string }) | undefined> => {
+  const result = await db
+    .select({
+      id: teamInvites.id,
+      teamId: teamInvites.teamId,
+      email: teamInvites.email,
+      role: teamInvites.role,
+      tokenHash: teamInvites.tokenHash,
+      expiresAt: teamInvites.expiresAt,
+      usedAt: teamInvites.usedAt,
+      createdBy: teamInvites.createdBy,
+      createdAt: teamInvites.createdAt,
+      teamName: teams.name,
+    })
+    .from(teamInvites)
+    .innerJoin(teams, eq(teamInvites.teamId, teams.id))
+    .where(
+      and(
+        eq(teamInvites.tokenHash, tokenHash),
+        gt(teamInvites.expiresAt, new Date()),
+        sql`${teamInvites.usedAt} IS NULL`
+      )
+    );
+  return result[0];
+};
+
+export const markTeamInviteUsed = async (inviteId: string): Promise<void> => {
+  await db
+    .update(teamInvites)
+    .set({ usedAt: new Date() })
+    .where(eq(teamInvites.id, inviteId));
+};
+
+export const listTeamInvites = async (
+  teamId: string
+): Promise<TeamInvite[]> => {
+  return db
+    .select()
+    .from(teamInvites)
+    .where(eq(teamInvites.teamId, teamId))
+    .orderBy(desc(teamInvites.createdAt));
+};
+
+export const listPendingInvitesForEmail = async (
+  email: string
+): Promise<(TeamInvite & { teamName: string })[]> => {
+  return db
+    .select({
+      id: teamInvites.id,
+      teamId: teamInvites.teamId,
+      email: teamInvites.email,
+      role: teamInvites.role,
+      tokenHash: teamInvites.tokenHash,
+      expiresAt: teamInvites.expiresAt,
+      usedAt: teamInvites.usedAt,
+      createdBy: teamInvites.createdBy,
+      createdAt: teamInvites.createdAt,
+      teamName: teams.name,
+    })
+    .from(teamInvites)
+    .innerJoin(teams, eq(teamInvites.teamId, teams.id))
+    .where(
+      and(
+        eq(teamInvites.email, email),
+        gt(teamInvites.expiresAt, new Date()),
+        sql`${teamInvites.usedAt} IS NULL`
+      )
+    )
+    .orderBy(desc(teamInvites.createdAt));
+};
+
+export const deleteTeamInvite = async (inviteId: string): Promise<boolean> => {
+  const result = await db
+    .delete(teamInvites)
+    .where(eq(teamInvites.id, inviteId))
+    .returning({ id: teamInvites.id });
+  return result.length > 0;
+};
+
+export const cleanupExpiredTeamInvites = async (): Promise<void> => {
+  await db.delete(teamInvites).where(lt(teamInvites.expiresAt, new Date()));
+};
+
+// =============================================================================
+// Team skill queries
+// =============================================================================
+
+export const createTeamSkill = async (
+  teamId: string,
+  skillKey: string,
+  createdBy: string
+): Promise<TeamSkill> => {
+  const result = await db
+    .insert(teamSkills)
+    .values({ teamId, skillKey, createdBy })
+    .returning();
+  return result[0]!;
+};
+
+export const findTeamSkillByKey = async (
+  teamId: string,
+  skillKey: string
+): Promise<TeamSkill | undefined> => {
+  const result = await db
+    .select()
+    .from(teamSkills)
+    .where(
+      and(eq(teamSkills.teamId, teamId), eq(teamSkills.skillKey, skillKey))
+    );
+  return result[0];
+};
+
+export const listTeamSkills = async (
+  teamId: string
+): Promise<Pick<TeamSkill, "id" | "skillKey" | "currentHash" | "updatedAt">[]> => {
+  return db
+    .select({
+      id: teamSkills.id,
+      skillKey: teamSkills.skillKey,
+      currentHash: teamSkills.currentHash,
+      updatedAt: teamSkills.updatedAt,
+    })
+    .from(teamSkills)
+    .where(eq(teamSkills.teamId, teamId))
+    .orderBy(desc(teamSkills.updatedAt));
+};
+
+export const updateTeamSkillCurrentHash = async (
+  skillId: string,
+  hash: string
+): Promise<void> => {
+  await db
+    .update(teamSkills)
+    .set({ currentHash: hash, updatedAt: new Date() })
+    .where(eq(teamSkills.id, skillId));
+};
+
+export const deleteTeamSkill = async (skillId: string): Promise<boolean> => {
+  const result = await db
+    .delete(teamSkills)
+    .where(eq(teamSkills.id, skillId))
+    .returning({ id: teamSkills.id });
+  return result.length > 0;
+};
+
+// =============================================================================
+// Team skill version queries
+// =============================================================================
+
+export const createTeamSkillVersion = async (
+  skillId: string,
+  hash: string,
+  encryptedData: string,
+  iv: string,
+  tag: string,
+  teamKeyVersion: number,
+  parentHash: string | null,
+  message: string | null,
+  createdBy: string
+): Promise<TeamSkillVersion> => {
+  const result = await db
+    .insert(teamSkillVersions)
+    .values({
+      skillId,
+      hash,
+      encryptedData,
+      iv,
+      tag,
+      teamKeyVersion,
+      parentHash,
+      message,
+      createdBy,
+    })
+    .onConflictDoUpdate({
+      target: [teamSkillVersions.skillId, teamSkillVersions.hash],
+      set: { encryptedData, iv, tag },
+    })
+    .returning();
+  return result[0]!;
+};
+
+export const findTeamSkillVersion = async (
+  skillId: string,
+  hash: string
+): Promise<TeamSkillVersion | undefined> => {
+  const result = await db
+    .select()
+    .from(teamSkillVersions)
+    .where(
+      and(
+        eq(teamSkillVersions.skillId, skillId),
+        eq(teamSkillVersions.hash, hash)
+      )
+    );
+  return result[0];
+};
+
+export const listTeamSkillVersions = async (
+  skillId: string,
+  limit = 50
+): Promise<TeamSkillVersion[]> => {
+  return db
+    .select()
+    .from(teamSkillVersions)
+    .where(eq(teamSkillVersions.skillId, skillId))
+    .orderBy(desc(teamSkillVersions.createdAt))
+    .limit(limit);
 };

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -11,6 +11,7 @@ import {
   primaryKey,
   uniqueIndex,
   index,
+  integer,
 } from "drizzle-orm/pg-core";
 
 // =============================================================================
@@ -23,6 +24,12 @@ export const users = pgTable("users", {
   salt: text("salt"),
   encryptedMasterKey: text("encrypted_master_key"),
   recoveryBlob: text("recovery_blob"),
+  // X25519 keypair for team key exchange
+  publicKey: text("public_key"),
+  publicKeyFingerprint: text("public_key_fingerprint"),
+  encryptedPrivateKey: text("encrypted_private_key"),
+  privateKeyIv: text("private_key_iv"),
+  privateKeyTag: text("private_key_tag"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
@@ -147,6 +154,184 @@ export type SkillVersion = typeof skillVersions.$inferSelect;
 export type NewSkillVersion = typeof skillVersions.$inferInsert;
 
 // =============================================================================
+// Teams Table
+// =============================================================================
+
+export const teams = pgTable("teams", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: text("name").notNull(),
+  activeKeyVersion: integer("active_key_version").notNull().default(1),
+  ownerId: uuid("owner_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export type Team = typeof teams.$inferSelect;
+export type NewTeam = typeof teams.$inferInsert;
+
+// =============================================================================
+// Team Members Table
+// =============================================================================
+
+export const teamMembers = pgTable(
+  "team_members",
+  {
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    role: text("role").notNull(), // 'owner', 'admin', 'editor', 'viewer'
+    status: text("status").notNull().default("pending"), // 'pending', 'active'
+    // Encrypted team key for this member (encrypted with their public key)
+    encryptedTeamKey: text("encrypted_team_key"),
+    teamKeyIv: text("team_key_iv"),
+    teamKeyTag: text("team_key_tag"),
+    ephemeralPublicKey: text("ephemeral_public_key"), // Sender's ephemeral key for decryption
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.teamId, table.userId] }),
+    index("idx_team_members_user_id").on(table.userId),
+  ]
+);
+
+export type TeamMember = typeof teamMembers.$inferSelect;
+export type NewTeamMember = typeof teamMembers.$inferInsert;
+
+// =============================================================================
+// Team Key Envelopes Table
+// =============================================================================
+
+export const teamKeyEnvelopes = pgTable(
+  "team_key_envelopes",
+  {
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    teamKeyVersion: integer("team_key_version").notNull(),
+    recipientUserId: uuid("recipient_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    wrappedByUserId: uuid("wrapped_by_user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    encryptedTeamKey: text("encrypted_team_key").notNull(),
+    iv: text("iv").notNull(),
+    tag: text("tag").notNull(),
+    ephemeralPublicKey: text("ephemeral_public_key").notNull(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.teamId, table.teamKeyVersion, table.recipientUserId],
+    }),
+    index("idx_team_key_envelopes_recipient").on(table.recipientUserId),
+    index("idx_team_key_envelopes_team_version").on(
+      table.teamId,
+      table.teamKeyVersion
+    ),
+  ]
+);
+
+export type TeamKeyEnvelope = typeof teamKeyEnvelopes.$inferSelect;
+export type NewTeamKeyEnvelope = typeof teamKeyEnvelopes.$inferInsert;
+
+// =============================================================================
+// Team Invites Table
+// =============================================================================
+
+export const teamInvites = pgTable(
+  "team_invites",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    role: text("role").notNull(), // 'admin', 'editor', 'viewer'
+    tokenHash: text("token_hash").notNull(), // SHA-256 hash of invite token
+    expiresAt: timestamp("expires_at").notNull(),
+    usedAt: timestamp("used_at"),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_team_invites_team_id").on(table.teamId),
+    index("idx_team_invites_email").on(table.email),
+    index("idx_team_invites_token_hash").on(table.tokenHash),
+  ]
+);
+
+export type TeamInvite = typeof teamInvites.$inferSelect;
+export type NewTeamInvite = typeof teamInvites.$inferInsert;
+
+// =============================================================================
+// Team Skills Table (skills shared with a team)
+// =============================================================================
+
+export const teamSkills = pgTable(
+  "team_skills",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    teamId: uuid("team_id")
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    skillKey: text("skill_key").notNull(),
+    currentHash: text("current_hash"),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_team_skills_team_skill").on(table.teamId, table.skillKey),
+    index("idx_team_skills_team_id").on(table.teamId),
+  ]
+);
+
+export type TeamSkill = typeof teamSkills.$inferSelect;
+export type NewTeamSkill = typeof teamSkills.$inferInsert;
+
+// =============================================================================
+// Team Skill Versions Table
+// =============================================================================
+
+export const teamSkillVersions = pgTable(
+  "team_skill_versions",
+  {
+    hash: text("hash").notNull(),
+    skillId: uuid("skill_id")
+      .notNull()
+      .references(() => teamSkills.id, { onDelete: "cascade" }),
+    encryptedData: text("encrypted_data").notNull(), // Encrypted with team key
+    iv: text("iv").notNull(),
+    tag: text("tag").notNull(),
+    teamKeyVersion: integer("team_key_version").notNull().default(1),
+    parentHash: text("parent_hash"),
+    message: text("message"),
+    createdBy: uuid("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.skillId, table.hash] }),
+    index("idx_team_skill_versions_skill_id").on(table.skillId),
+  ]
+);
+
+export type TeamSkillVersion = typeof teamSkillVersions.$inferSelect;
+export type NewTeamSkillVersion = typeof teamSkillVersions.$inferInsert;
+
+// =============================================================================
 // Legacy Type Aliases (for backward compatibility with existing code)
 // =============================================================================
 
@@ -156,3 +341,8 @@ export type SessionRecord = Session;
 export type BlobRecord = Blob;
 export type SkillRecord = Skill;
 export type SkillVersionRecord = SkillVersion;
+export type TeamRecord = Team;
+export type TeamMemberRecord = TeamMember;
+export type TeamInviteRecord = TeamInvite;
+export type TeamSkillRecord = TeamSkill;
+export type TeamSkillVersionRecord = TeamSkillVersion;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,8 +11,10 @@ import { authRoutes } from "./routes/auth.js";
 import { blobRoutes } from "./routes/blobs.js";
 import { accountRoutes } from "./routes/account.js";
 import { skillsRouter } from "./routes/skills.js";
+import { teamsRouter } from "./routes/teams.js";
 
 const app = new Hono();
+const enableTeamSharing = process.env["ENABLE_TEAM_SHARING"] === "true";
 
 // Middleware
 app.use("*", logger());
@@ -55,6 +57,9 @@ app.route("/auth", authRoutes);
 app.route("/blobs", blobRoutes);
 app.route("/account", accountRoutes);
 app.route("/skills", skillsRouter);
+if (enableTeamSharing) {
+  app.route("/teams", teamsRouter);
+}
 
 // 404 handler
 app.notFound((c) => {
@@ -71,6 +76,7 @@ app.onError((err, c) => {
 const port = parseInt(process.env["PORT"] ?? "3001", 10);
 
 console.log(`Starting server on port ${port}...`);
+console.log(`Team sharing routes: ${enableTeamSharing ? "enabled" : "disabled"}`);
 
 serve({
   fetch: app.fetch,

--- a/packages/server/src/routes/account.ts
+++ b/packages/server/src/routes/account.ts
@@ -8,6 +8,8 @@ import {
   updateUserSalt,
   updateUserRecoveryBlob,
   updateUserEncryptedMasterKey,
+  getUserKeyPair,
+  updateUserPublicKey,
   deleteUser,
   deleteUserSessions,
   countUserBlobs,
@@ -175,6 +177,61 @@ accountRoutes.put("/master-key", async (c) => {
   }
 
   await updateUserEncryptedMasterKey(user.id, body.encryptedMasterKey);
+
+  return c.json({ success: true });
+});
+
+/**
+ * Get account sharing keypair backup metadata
+ * GET /account/sharing-key
+ */
+accountRoutes.get("/sharing-key", async (c) => {
+  const jwtUser = getUser(c);
+  const keyPair = await getUserKeyPair(jwtUser.sub);
+
+  if (!keyPair) {
+    return c.json({ hasKeypair: false });
+  }
+
+  return c.json({
+    hasKeypair: true,
+    publicKey: keyPair.publicKey,
+    publicKeyFingerprint: keyPair.publicKeyFingerprint,
+    encryptedPrivateKey: keyPair.encryptedPrivateKey,
+    privateKeyIv: keyPair.privateKeyIv,
+    privateKeyTag: keyPair.privateKeyTag,
+  });
+});
+
+/**
+ * Set account sharing keypair backup
+ * PUT /account/sharing-key
+ */
+accountRoutes.put("/sharing-key", async (c) => {
+  const jwtUser = getUser(c);
+  const body = await c.req.json<{
+    publicKey?: string;
+    encryptedPrivateKey?: string;
+    privateKeyIv?: string;
+    privateKeyTag?: string;
+  }>();
+
+  if (
+    !body.publicKey ||
+    !body.encryptedPrivateKey ||
+    !body.privateKeyIv ||
+    !body.privateKeyTag
+  ) {
+    return c.json({ error: "Missing required sharing key fields" }, 400);
+  }
+
+  await updateUserPublicKey(
+    jwtUser.sub,
+    body.publicKey,
+    body.encryptedPrivateKey,
+    body.privateKeyIv,
+    body.privateKeyTag
+  );
 
   return c.json({ success: true });
 });

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -1,0 +1,964 @@
+/**
+ * Team routes for managing teams, members, invites, and team skills
+ */
+
+import { Hono } from "hono";
+import { authMiddleware, getUser } from "../middleware.js";
+import { hashToken, generateToken } from "../auth.js";
+import {
+  // Team queries
+  createTeam,
+  findTeamById,
+  updateTeamName,
+  deleteTeam,
+  listUserTeams,
+  // Member queries
+  addTeamMember,
+  findTeamMember,
+  updateTeamMemberRole,
+  setTeamMemberKey,
+  removeTeamMember,
+  rotateTeamKeyAndRemoveMember,
+  listTeamMembers,
+  listPendingTeamMembers,
+  listAllPendingMembersForUser,
+  getTeamActiveKeyVersion,
+  getActiveTeamKeyEnvelopeForMember,
+  // Invite queries
+  createTeamInvite,
+  findValidTeamInvite,
+  markTeamInviteUsed,
+  listTeamInvites,
+  listPendingInvitesForEmail,
+  deleteTeamInvite,
+  // User queries
+  findUserByEmail,
+  getUserPublicKey,
+  updateUserPublicKey,
+  getUserKeyPair,
+  // Team skill queries
+  createTeamSkill,
+  findTeamSkillByKey,
+  listTeamSkills,
+  updateTeamSkillCurrentHash,
+  deleteTeamSkill,
+  createTeamSkillVersion,
+  findTeamSkillVersion,
+  listTeamSkillVersions,
+} from "../db/index.js";
+
+export const teamsRouter = new Hono();
+
+// All team routes require authentication
+teamsRouter.use("*", authMiddleware);
+
+// =============================================================================
+// Team CRUD
+// =============================================================================
+
+/**
+ * List all teams the user is a member of
+ * GET /teams
+ */
+teamsRouter.get("/", async (c) => {
+  const user = getUser(c);
+  const teams = await listUserTeams(user.sub);
+
+  return c.json({
+    teams: teams.map((t) => ({
+      id: t.id,
+      name: t.name,
+      role: t.role,
+      status: t.status,
+      memberCount: t.memberCount,
+    skillCount: t.skillCount,
+    activeKeyVersion: t.activeKeyVersion,
+    createdAt: t.createdAt,
+  })),
+  });
+});
+
+/**
+ * Create a new team
+ * POST /teams
+ */
+teamsRouter.post("/", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json<{ name: string }>();
+
+  if (!body.name || body.name.trim().length === 0) {
+    return c.json({ error: "Team name is required" }, 400);
+  }
+
+  // Create team
+  const team = await createTeam(body.name.trim(), user.sub);
+
+  // Add creator as owner with active status
+  await addTeamMember(team.id, user.sub, "owner", "active");
+
+  return c.json({
+    id: team.id,
+    name: team.name,
+    role: "owner",
+    status: "active",
+    activeKeyVersion: team.activeKeyVersion,
+    createdAt: team.createdAt,
+  });
+});
+
+/**
+ * Get team details
+ * GET /teams/:teamId
+ */
+teamsRouter.get("/:teamId", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  // Check membership
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership) {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  const team = await findTeamById(teamId);
+  if (!team) {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  const members = await listTeamMembers(teamId);
+  const skills = await listTeamSkills(teamId);
+
+  return c.json({
+    id: team.id,
+    name: team.name,
+    role: membership.role,
+    status: membership.status,
+    members: members.map((m) => ({
+      userId: m.userId,
+      email: m.email,
+      role: m.role,
+      status: m.status,
+      hasTeamKey: !!m.encryptedTeamKey,
+      createdAt: m.createdAt,
+    })),
+    skills: skills.map((s) => ({
+      id: s.id,
+      skillKey: s.skillKey,
+      currentHash: s.currentHash,
+      updatedAt: s.updatedAt,
+    })),
+    createdAt: team.createdAt,
+    activeKeyVersion: team.activeKeyVersion,
+  });
+});
+
+/**
+ * Update team name
+ * PUT /teams/:teamId
+ */
+teamsRouter.put("/:teamId", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const body = await c.req.json<{ name: string }>();
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Only the team owner can rename the team" }, 403);
+  }
+
+  if (!body.name || body.name.trim().length === 0) {
+    return c.json({ error: "Team name is required" }, 400);
+  }
+
+  await updateTeamName(teamId, body.name.trim());
+
+  return c.json({ success: true });
+});
+
+/**
+ * Delete team (owner only)
+ * DELETE /teams/:teamId
+ */
+teamsRouter.delete("/:teamId", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Only the team owner can delete the team" }, 403);
+  }
+
+  await deleteTeam(teamId);
+
+  return c.json({ success: true });
+});
+
+// =============================================================================
+// Team Members
+// =============================================================================
+
+/**
+ * List team members
+ * GET /teams/:teamId/members
+ */
+teamsRouter.get("/:teamId/members", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  // Check membership
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership) {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  const members = await listTeamMembers(teamId);
+
+  return c.json({
+    members: members.map((m) => ({
+      userId: m.userId,
+      email: m.email,
+      role: m.role,
+      status: m.status,
+      hasTeamKey: !!m.encryptedTeamKey,
+      createdAt: m.createdAt,
+    })),
+  });
+});
+
+/**
+ * Update member role
+ * PUT /teams/:teamId/members/:userId
+ */
+teamsRouter.put("/:teamId/members/:userId", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const targetUserId = c.req.param("userId");
+  const body = await c.req.json<{ role: string }>();
+
+  // Check permission (owner or admin)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || !["owner", "admin"].includes(membership.role)) {
+    return c.json({ error: "Permission denied" }, 403);
+  }
+
+  // Cannot change owner's role
+  const targetMembership = await findTeamMember(teamId, targetUserId);
+  if (!targetMembership) {
+    return c.json({ error: "Member not found" }, 404);
+  }
+
+  if (targetMembership.role === "owner") {
+    return c.json({ error: "Cannot change owner's role" }, 400);
+  }
+
+  // Validate role
+  const validRoles = ["admin", "editor", "viewer"];
+  if (!validRoles.includes(body.role)) {
+    return c.json({ error: "Invalid role" }, 400);
+  }
+
+  await updateTeamMemberRole(teamId, targetUserId, body.role);
+
+  return c.json({ success: true });
+});
+
+/**
+ * Remove member from team
+ * DELETE /teams/:teamId/members/:userId
+ */
+teamsRouter.delete("/:teamId/members/:userId", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const targetUserId = c.req.param("userId");
+
+  const body = await c.req.json<{
+    nextTeamKeyVersion?: number;
+    envelopes?: Array<{
+      recipientUserId: string;
+      encryptedTeamKey: string;
+      iv: string;
+      tag: string;
+      ephemeralPublicKey: string;
+    }>;
+  }>();
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  // Cannot remove owner
+  const targetMembership = await findTeamMember(teamId, targetUserId);
+  if (!targetMembership) {
+    return c.json({ error: "Member not found" }, 404);
+  }
+
+  if (targetMembership.role === "owner") {
+    return c.json({ error: "Cannot remove team owner" }, 400);
+  }
+
+  const activeKeyVersion = await getTeamActiveKeyVersion(teamId);
+  if (!activeKeyVersion) {
+    return c.json({ error: "Team key version not found" }, 500);
+  }
+
+  const nextTeamKeyVersion = body.nextTeamKeyVersion ?? activeKeyVersion + 1;
+  if (nextTeamKeyVersion <= activeKeyVersion) {
+    return c.json({ error: "nextTeamKeyVersion must be greater than the active version" }, 400);
+  }
+
+  if (!body.envelopes || body.envelopes.length === 0) {
+    return c.json({ error: "Rotation envelopes are required when removing a member" }, 400);
+  }
+
+  await rotateTeamKeyAndRemoveMember(
+    teamId,
+    targetUserId,
+    nextTeamKeyVersion,
+    user.sub,
+    body.envelopes
+  );
+
+  return c.json({ success: true, activeKeyVersion: nextTeamKeyVersion });
+});
+
+/**
+ * Get pending members waiting for key distribution
+ * GET /teams/:teamId/members/pending
+ */
+teamsRouter.get("/:teamId/members/pending", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Only the team owner can distribute team keys" }, 403);
+  }
+
+  const pendingMembers = await listPendingTeamMembers(teamId);
+
+  // Get public keys for pending members
+  const membersWithKeys = await Promise.all(
+    pendingMembers.map(async (m) => {
+      const keyInfo = await getUserPublicKey(m.userId);
+      return {
+        userId: m.userId,
+        email: m.email,
+        role: m.role,
+        publicKey: keyInfo?.publicKey ?? null,
+        publicKeyFingerprint: keyInfo?.publicKeyFingerprint ?? null,
+        createdAt: m.createdAt,
+      };
+    })
+  );
+
+  return c.json({ pendingMembers: membersWithKeys });
+});
+
+/**
+ * Get all pending members across all teams user can manage
+ * GET /teams/pending-members
+ */
+teamsRouter.get("/pending-members", async (c) => {
+  const user = getUser(c);
+  const pendingMembers = await listAllPendingMembersForUser(user.sub);
+
+  return c.json({
+    pendingMembers: pendingMembers.map((m) => ({
+      teamId: m.teamId,
+      teamName: m.teamName,
+      userId: m.userId,
+      email: m.email,
+      role: m.role,
+      publicKey: m.memberPublicKey,
+      publicKeyFingerprint: m.memberPublicKeyFingerprint,
+      createdAt: m.createdAt,
+    })),
+  });
+});
+
+/**
+ * Distribute team key to a pending member
+ * POST /teams/:teamId/members/:userId/key
+ */
+teamsRouter.post("/:teamId/members/:userId/key", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const targetUserId = c.req.param("userId");
+
+  const body = await c.req.json<{
+    encryptedTeamKey: string;
+    iv: string;
+    tag: string;
+    ephemeralPublicKey: string;
+    teamKeyVersion?: number;
+  }>();
+
+  // Check permission (owner with active status)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (
+    !membership ||
+    membership.role !== "owner" ||
+    membership.status !== "active"
+  ) {
+    return c.json({ error: "Permission denied" }, 403);
+  }
+
+  // Check target is pending
+  const targetMembership = await findTeamMember(teamId, targetUserId);
+  if (!targetMembership || targetMembership.status !== "pending") {
+    return c.json({ error: "Member not found or not pending" }, 404);
+  }
+
+  // Validate required fields
+  if (
+    !body.encryptedTeamKey ||
+    !body.iv ||
+    !body.tag ||
+    !body.ephemeralPublicKey
+  ) {
+    return c.json({ error: "Missing required key fields" }, 400);
+  }
+
+  const activeKeyVersion = await getTeamActiveKeyVersion(teamId);
+  if (!activeKeyVersion) {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  const teamKeyVersion = body.teamKeyVersion ?? activeKeyVersion;
+  if (teamKeyVersion !== activeKeyVersion) {
+    return c.json({ error: "Team key version must match the active team key version" }, 409);
+  }
+
+  // Set the team key for the member
+  await setTeamMemberKey(
+    teamId,
+    targetUserId,
+    body.encryptedTeamKey,
+    body.iv,
+    body.tag,
+    body.ephemeralPublicKey,
+    teamKeyVersion,
+    user.sub
+  );
+
+  return c.json({ success: true, teamKeyVersion });
+});
+
+/**
+ * Get my team key (for active members)
+ * GET /teams/:teamId/my-key
+ */
+teamsRouter.get("/:teamId/my-key", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership) {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  const activeEnvelope = await getActiveTeamKeyEnvelopeForMember(teamId, user.sub);
+  if (!activeEnvelope) {
+    return c.json({ error: "Team key not available", status: membership.status }, 404);
+  }
+
+  return c.json({
+    encryptedTeamKey: activeEnvelope.encryptedTeamKey,
+    iv: activeEnvelope.iv,
+    tag: activeEnvelope.tag,
+    ephemeralPublicKey: activeEnvelope.ephemeralPublicKey,
+    teamKeyVersion: activeEnvelope.teamKeyVersion,
+    status: membership.status,
+  });
+});
+
+// =============================================================================
+// Team Invites
+// =============================================================================
+
+/**
+ * List team invites
+ * GET /teams/:teamId/invites
+ */
+teamsRouter.get("/:teamId/invites", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Only the team owner can list invites" }, 403);
+  }
+
+  const invites = await listTeamInvites(teamId);
+
+  return c.json({
+    invites: invites.map((i) => ({
+      id: i.id,
+      email: i.email,
+      role: i.role,
+      expiresAt: i.expiresAt,
+      usedAt: i.usedAt,
+      createdAt: i.createdAt,
+    })),
+  });
+});
+
+/**
+ * Create team invite
+ * POST /teams/:teamId/invites
+ */
+teamsRouter.post("/:teamId/invites", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  const body = await c.req.json<{
+    email: string;
+    role: string;
+  }>();
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Only the team owner can create invites" }, 403);
+  }
+
+  // Validate email
+  if (!body.email || !body.email.includes("@")) {
+    return c.json({ error: "Invalid email" }, 400);
+  }
+
+  // Validate role
+  const validRoles = ["admin", "editor", "viewer"];
+  if (!validRoles.includes(body.role)) {
+    return c.json({ error: "Invalid role" }, 400);
+  }
+
+  // Check if user is already a member
+  const existingUser = await findUserByEmail(body.email);
+  if (existingUser) {
+    const existingMembership = await findTeamMember(teamId, existingUser.id);
+    if (existingMembership) {
+      return c.json({ error: "User is already a team member" }, 400);
+    }
+  }
+
+  // Generate secure invite token
+  const token = generateToken();
+  const tokenHash = hashToken(token);
+
+  // Create invite (72 hour expiry)
+  const invite = await createTeamInvite(
+    teamId,
+    body.email.toLowerCase(),
+    body.role,
+    tokenHash,
+    user.sub,
+    72
+  );
+
+  return c.json({
+    id: invite.id,
+    token, // Return plaintext token to be sent to invitee
+    email: invite.email,
+    role: invite.role,
+    expiresAt: invite.expiresAt,
+  });
+});
+
+/**
+ * Delete/revoke team invite
+ * DELETE /teams/:teamId/invites/:inviteId
+ */
+teamsRouter.delete("/:teamId/invites/:inviteId", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const inviteId = c.req.param("inviteId");
+
+  // Check permission (owner only)
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.role !== "owner") {
+    return c.json({ error: "Only the team owner can revoke invites" }, 403);
+  }
+
+  await deleteTeamInvite(inviteId);
+
+  return c.json({ success: true });
+});
+
+/**
+ * Accept team invite (validates token and adds user as member)
+ * POST /teams/invites/accept
+ */
+teamsRouter.post("/invites/accept", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json<{ token: string }>();
+
+  if (!body.token) {
+    return c.json({ error: "Invite token is required" }, 400);
+  }
+
+  const tokenHash = hashToken(body.token);
+  const invite = await findValidTeamInvite(tokenHash);
+
+  if (!invite) {
+    return c.json({ error: "Invalid or expired invite" }, 404);
+  }
+
+  // Check email matches (security: prevent token theft)
+  if (invite.email.toLowerCase() !== user.email.toLowerCase()) {
+    return c.json({ error: "This invite was sent to a different email address" }, 403);
+  }
+
+  // Check not already a member
+  const existingMembership = await findTeamMember(invite.teamId, user.sub);
+  if (existingMembership) {
+    return c.json({ error: "You are already a member of this team" }, 400);
+  }
+
+  // Mark invite as used
+  await markTeamInviteUsed(invite.id);
+
+  // Add user as pending member (will become active once they receive team key)
+  await addTeamMember(invite.teamId, user.sub, invite.role, "pending");
+
+  return c.json({
+    teamId: invite.teamId,
+    teamName: invite.teamName,
+    role: invite.role,
+    status: "pending",
+    message: "Invite accepted. Waiting for team key from team admin.",
+  });
+});
+
+/**
+ * Get pending invites for current user
+ * GET /teams/invites/pending
+ */
+teamsRouter.get("/invites/pending", async (c) => {
+  const user = getUser(c);
+  const invites = await listPendingInvitesForEmail(user.email);
+
+  return c.json({
+    invites: invites.map((i) => ({
+      id: i.id,
+      teamId: i.teamId,
+      teamName: i.teamName,
+      role: i.role,
+      expiresAt: i.expiresAt,
+      createdAt: i.createdAt,
+    })),
+  });
+});
+
+// =============================================================================
+// User Keypair (for team key exchange)
+// =============================================================================
+
+/**
+ * Get current user's public key
+ * GET /teams/keypair
+ */
+teamsRouter.get("/keypair", async (c) => {
+  const user = getUser(c);
+  const keyPair = await getUserKeyPair(user.sub);
+
+  if (!keyPair) {
+    return c.json({ hasKeypair: false });
+  }
+
+  return c.json({
+    hasKeypair: true,
+    publicKey: keyPair.publicKey,
+    publicKeyFingerprint: keyPair.publicKeyFingerprint,
+    encryptedPrivateKey: keyPair.encryptedPrivateKey,
+    privateKeyIv: keyPair.privateKeyIv,
+    privateKeyTag: keyPair.privateKeyTag,
+  });
+});
+
+/**
+ * Set user's keypair (encrypted private key stored)
+ * PUT /teams/keypair
+ */
+teamsRouter.put("/keypair", async (c) => {
+  const user = getUser(c);
+  const body = await c.req.json<{
+    publicKey: string;
+    encryptedPrivateKey: string;
+    privateKeyIv: string;
+    privateKeyTag: string;
+  }>();
+
+  if (
+    !body.publicKey ||
+    !body.encryptedPrivateKey ||
+    !body.privateKeyIv ||
+    !body.privateKeyTag
+  ) {
+    return c.json({ error: "Missing required keypair fields" }, 400);
+  }
+
+  await updateUserPublicKey(
+    user.sub,
+    body.publicKey,
+    body.encryptedPrivateKey,
+    body.privateKeyIv,
+    body.privateKeyTag
+  );
+
+  return c.json({ success: true });
+});
+
+// =============================================================================
+// Team Skills
+// =============================================================================
+
+/**
+ * List team skills
+ * GET /teams/:teamId/skills
+ */
+teamsRouter.get("/:teamId/skills", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+
+  // Check membership and active status
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.status !== "active") {
+    return c.json({ error: "Team not found or access denied" }, 404);
+  }
+
+  const skills = await listTeamSkills(teamId);
+
+  return c.json({
+    skills: skills.map((s) => ({
+      id: s.id,
+      skillKey: s.skillKey,
+      currentHash: s.currentHash,
+      updatedAt: s.updatedAt,
+    })),
+  });
+});
+
+/**
+ * Push a new version of a team skill
+ * POST /teams/:teamId/skills/:skillKey/versions
+ */
+teamsRouter.post("/:teamId/skills/:skillKey/versions", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const skillKey = c.req.param("skillKey");
+
+  // Check membership, active status, and write permission
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.status !== "active") {
+    return c.json({ error: "Team not found or access denied" }, 404);
+  }
+
+  if (!["owner", "admin", "editor"].includes(membership.role)) {
+    return c.json({ error: "Permission denied" }, 403);
+  }
+
+  const body = await c.req.json<{
+    hash: string;
+    encryptedData: string;
+    iv: string;
+    tag: string;
+    teamKeyVersion: number;
+    message?: string;
+  }>();
+
+  if (!body.hash || !body.encryptedData || !body.iv || !body.tag) {
+    return c.json({ error: "Missing required fields" }, 400);
+  }
+
+  const activeKeyVersion = await getTeamActiveKeyVersion(teamId);
+  if (!activeKeyVersion) {
+    return c.json({ error: "Team not found" }, 404);
+  }
+
+  if (body.teamKeyVersion !== activeKeyVersion) {
+    return c.json({ error: "Writes must use the active team key version" }, 409);
+  }
+
+  // Find or create skill
+  let skill = await findTeamSkillByKey(teamId, skillKey);
+  if (!skill) {
+    skill = await createTeamSkill(teamId, skillKey, user.sub);
+  }
+
+  // Get parent hash (current version before this push)
+  const parentHash = skill.currentHash;
+
+  // Create the version
+  const version = await createTeamSkillVersion(
+    skill.id,
+    body.hash,
+    body.encryptedData,
+    body.iv,
+    body.tag,
+    body.teamKeyVersion,
+    parentHash,
+    body.message ?? null,
+    user.sub
+  );
+
+  // Update current hash
+  await updateTeamSkillCurrentHash(skill.id, body.hash);
+
+  return c.json({
+    skillId: skill.id,
+    hash: version.hash,
+    teamKeyVersion: version.teamKeyVersion,
+    parentHash: version.parentHash,
+    createdAt: version.createdAt,
+  });
+});
+
+/**
+ * Get the current (latest) version of a team skill
+ * GET /teams/:teamId/skills/:skillKey
+ */
+teamsRouter.get("/:teamId/skills/:skillKey", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const skillKey = c.req.param("skillKey");
+
+  // Check membership and active status
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.status !== "active") {
+    return c.json({ error: "Team not found or access denied" }, 404);
+  }
+
+  const skill = await findTeamSkillByKey(teamId, skillKey);
+  if (!skill) {
+    return c.json({ error: "Skill not found" }, 404);
+  }
+
+  if (!skill.currentHash) {
+    return c.json({ error: "Skill has no versions" }, 404);
+  }
+
+  const version = await findTeamSkillVersion(skill.id, skill.currentHash);
+  if (!version) {
+    return c.json({ error: "Current version not found" }, 404);
+  }
+
+  return c.json({
+    skillKey,
+    skillId: skill.id,
+    hash: version.hash,
+    encryptedData: version.encryptedData,
+    iv: version.iv,
+    tag: version.tag,
+    teamKeyVersion: version.teamKeyVersion,
+    parentHash: version.parentHash,
+    message: version.message,
+    createdAt: version.createdAt,
+  });
+});
+
+/**
+ * Get version history for a team skill
+ * GET /teams/:teamId/skills/:skillKey/versions
+ */
+teamsRouter.get("/:teamId/skills/:skillKey/versions", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const skillKey = c.req.param("skillKey");
+  const limit = parseInt(c.req.query("limit") ?? "50", 10);
+
+  // Check membership and active status
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.status !== "active") {
+    return c.json({ error: "Team not found or access denied" }, 404);
+  }
+
+  const skill = await findTeamSkillByKey(teamId, skillKey);
+  if (!skill) {
+    return c.json({ error: "Skill not found" }, 404);
+  }
+
+  const versions = await listTeamSkillVersions(skill.id, limit);
+
+  return c.json({
+    skillKey,
+    currentHash: skill.currentHash,
+    versions: versions.map((v) => ({
+      hash: v.hash,
+      teamKeyVersion: v.teamKeyVersion,
+      parentHash: v.parentHash,
+      message: v.message,
+      createdAt: v.createdAt,
+    })),
+  });
+});
+
+/**
+ * Get a specific version of a team skill
+ * GET /teams/:teamId/skills/:skillKey/versions/:hash
+ */
+teamsRouter.get("/:teamId/skills/:skillKey/versions/:hash", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const skillKey = c.req.param("skillKey");
+  const hash = c.req.param("hash");
+
+  // Check membership and active status
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || membership.status !== "active") {
+    return c.json({ error: "Team not found or access denied" }, 404);
+  }
+
+  const skill = await findTeamSkillByKey(teamId, skillKey);
+  if (!skill) {
+    return c.json({ error: "Skill not found" }, 404);
+  }
+
+  const version = await findTeamSkillVersion(skill.id, hash);
+  if (!version) {
+    return c.json({ error: "Version not found" }, 404);
+  }
+
+  return c.json({
+    skillKey,
+    hash: version.hash,
+    encryptedData: version.encryptedData,
+    iv: version.iv,
+    tag: version.tag,
+    teamKeyVersion: version.teamKeyVersion,
+    parentHash: version.parentHash,
+    message: version.message,
+    createdAt: version.createdAt,
+  });
+});
+
+/**
+ * Delete a team skill (owner/admin only)
+ * DELETE /teams/:teamId/skills/:skillKey
+ */
+teamsRouter.delete("/:teamId/skills/:skillKey", async (c) => {
+  const user = getUser(c);
+  const teamId = c.req.param("teamId");
+  const skillKey = c.req.param("skillKey");
+
+  // Check membership and permission
+  const membership = await findTeamMember(teamId, user.sub);
+  if (!membership || !["owner", "admin"].includes(membership.role)) {
+    return c.json({ error: "Permission denied" }, 403);
+  }
+
+  const skill = await findTeamSkillByKey(teamId, skillKey);
+  if (!skill) {
+    return c.json({ error: "Skill not found" }, 404);
+  }
+
+  await deleteTeamSkill(skill.id);
+
+  return c.json({ success: true });
+});


### PR DESCRIPTION
## Summary
- add team sharing CLI, server routes, and core crypto support
- add public-key fingerprints, versioned team-key envelopes, and owner-driven key rotation flow
- add production rollout docs, dark-launch flag, and an incremental SQL migration for the existing live database

## Validation
- yarn typecheck
- yarn workspace @claudeskill/core test
- yarn workspace @claudeskill/core build
- yarn workspace @claudeskill/cli build
- yarn workspace @claude-skill-sync/server build

## Rollout notes
- apply `packages/server/drizzle/prod/20260311_team_share_incremental.sql` to production before enabling team routes
- deploy once with `ENABLE_TEAM_SHARING=false`, verify personal sync, then redeploy with it set to `true`
- publish the CLI update only after the production smoke test passes
