### PR TITLE
fix: improve hidden file filtering with tests and deduplication

### DIFF
--- a/packages/cli/src/sync.ts
+++ b/packages/cli/src/sync.ts
@@ -16,6 +16,7 @@ import {
   getClaudeDir,
   computeSkillHash,
   getSkillKey,
+  isHiddenSkillKey,
   type Skill,
   type SkillType,
 } from "@claudeskill/core";
@@ -237,21 +238,29 @@ export const pushSkills = async (
     .map((r) => r.type === 'error' ? r.message : '');
 
   // Delete remote skills with hidden-file names (e.g. .DS_Store, .gitignore
-  // that were synced before the filter was in place)
-  const localSkillKeys = new Set(skills.map((s) => getSkillKey(s)));
-  const remoteList = await api.listSkills();
-  if (remoteList.ok) {
-    const hiddenRemote = (remoteList.data as { skills: { skillKey: string }[] }).skills.filter((s) => {
-      const name = s.skillKey.split(':').slice(1).join(':');
-      return name.startsWith('.');
-    });
-    await Promise.all(
-      hiddenRemote.map(async (s) => {
-        onProgress?.(`Removing hidden file ${s.skillKey} from remote...`);
-        await api.deleteSkill(s.skillKey);
-        delete index.skills[s.skillKey];
-      })
-    );
+  // that were synced before the filter was in place).
+  // Only fetch the remote list when local hidden skills exist, to avoid an
+  // extra API call on every push.
+  const hasLocalHidden = skills.some((s) => isHiddenSkillKey(getSkillKey(s)));
+  if (hasLocalHidden) {
+    const remoteList = await api.listSkills();
+    if (remoteList.ok) {
+      const hiddenRemote = (remoteList.data as { skills: { skillKey: string }[] }).skills.filter((s) =>
+        isHiddenSkillKey(s.skillKey)
+      );
+      const deleteResults = await Promise.allSettled(
+        hiddenRemote.map(async (s) => {
+          onProgress?.(`Removing hidden file ${s.skillKey} from remote...`);
+          await api.deleteSkill(s.skillKey);
+          delete index.skills[s.skillKey];
+        })
+      );
+      for (const r of deleteResults) {
+        if (r.status === 'rejected') {
+          onProgress?.(`Warning: failed to delete hidden remote skill: ${r.reason}`);
+        }
+      }
+    }
   }
 
   // Save updated index
@@ -292,8 +301,7 @@ export const pullSkills = async (
     .filter((remoteSkill) => {
       // Skip hidden-named skills (e.g. .DS_Store, .gitignore) — they should
       // never have been synced and must not be written to disk
-      const name = remoteSkill.skillKey.split(':').slice(1).join(':');
-      return !name.startsWith('.');
+      return !isHiddenSkillKey(remoteSkill.skillKey);
     })
     .map(async (remoteSkill) => {
       const existing = index.skills[remoteSkill.skillKey];
@@ -430,8 +438,7 @@ export const getSyncStatus = async () => {
   const localSkillKeys = new Set(skills.map((s) => getSkillKey(s)));
   const pendingPull = listResult.ok
     ? listResult.data.skills.filter((s) => {
-        const name = s.skillKey.split(':').slice(1).join(':');
-        return s.currentHash && !localSkillKeys.has(s.skillKey) && !name.startsWith('.');
+        return s.currentHash && !localSkillKeys.has(s.skillKey) && !isHiddenSkillKey(s.skillKey);
       }).length
     : 0;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export {
   getSkillDescription,
   getSkillKey,
   getSkillSize,
+  isHiddenSkillKey,
   getSkillsPath,
   getSkillTools,
   getSkillTriggers,

--- a/packages/core/src/skill.test.ts
+++ b/packages/core/src/skill.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isHiddenSkillKey } from "./skill.js";
+
+describe("isHiddenSkillKey", () => {
+  it("returns true for hidden skill keys", () => {
+    assert.equal(isHiddenSkillKey("md:.DS_Store"), true);
+    assert.equal(isHiddenSkillKey("md:.gitignore"), true);
+    assert.equal(isHiddenSkillKey("md:.env"), true);
+  });
+
+  it("returns false for normal skill keys", () => {
+    assert.equal(isHiddenSkillKey("md:my-skill"), false);
+    assert.equal(isHiddenSkillKey("md:another-skill"), false);
+  });
+
+  it("handles keys with multiple colons", () => {
+    assert.equal(isHiddenSkillKey("md:some:skill"), false);
+    assert.equal(isHiddenSkillKey("md:.hidden:file"), true);
+  });
+});

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -567,3 +567,11 @@ export const computeSkillHash = (skill: Skill): string => {
 export const getSkillKey = (skill: Skill): string => {
   return `${skill.type}:${skill.name}`;
 };
+
+/**
+ * Check if a skill key refers to a hidden file (e.g. .DS_Store, .gitignore)
+ */
+export const isHiddenSkillKey = (skillKey: string): boolean => {
+  const name = skillKey.split(':').slice(1).join(':');
+  return name.startsWith('.');
+};


### PR DESCRIPTION
## Summary
Follow-up to #15 — adds improvements identified in review:

- Extract `isHiddenSkillKey()` helper to core package (eliminates 3x duplication)
- Add unit tests for hidden file detection
- Gate remote cleanup to only run when hidden skills exist locally
- Use `Promise.allSettled` for deletion error handling

## Test plan
- [ ] `isHiddenSkillKey` tests pass
- [ ] Push/pull still works with no hidden files (no extra API calls)
- [ ] Push correctly cleans up hidden remote skills when they exist