### PR TITLE
chore: add aggregate ci gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,14 @@ jobs:
 
       - name: Test
         run: bun run test
+
+  ci-ok:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: always()
+    steps:
+      - name: Verify CI result
+        run: |
+          if [ "${{ needs.build-and-test.result }}" != "success" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a stable aggregate `ci-ok` job for future branch protection
- keep the existing Bun install, build, typecheck, and test gate unchanged
- intentionally do not add lint because current main has pre-existing Biome lint findings

## Local validation
- bun install --frozen-lockfile passed
- bun run lint failed on current main with pre-existing Biome findings, so lint is documented but not added as a new gate

## GitHub validation
- build-and-test: pass
- ci-ok: pass

No app code changes. No merge or branch-protection changes.